### PR TITLE
Add x402engine gateway provider

### DIFF
--- a/providers/x402engine/gateway/PAY.md
+++ b/providers/x402engine/gateway/PAY.md
@@ -1,0 +1,32 @@
+---
+name: gateway
+title: "x402engine"
+description: "Pay-per-call gateway with 108 agent APIs: 72 LLMs, image and video generation, audio, web search, code execution, crypto and wallet data, travel, and IPFS."
+use_case: "Use for model inference, media generation, transcription, speech synthesis, web research, sandboxed code, market data, wallet analytics, travel search, and storage without API keys or subscriptions."
+category: ai_ml
+service_url: https://x402engine.app
+openapi:
+  path: openapi.json
+---
+
+x402engine exposes 108 HTTP APIs through x402 v2. Agents pay only for the
+requested operation using USDC on Solana or Base, or USDm on MegaETH. No
+account, API key, subscription, or prepaid balance is required.
+
+The catalog includes 72 language models from OpenAI, Anthropic, Google, xAI,
+DeepSeek, Qwen, MiniMax, GLM, Meta, Mistral, and other providers. It also
+includes image and video generation, text-to-speech, transcription, web search
+and scraping, sandboxed code execution, embeddings, crypto market data, wallet
+analytics, transaction simulation, travel search, and IPFS storage.
+
+## Spend-aware usage
+
+- Call the free discovery document before selecting a paid route:
+  `GET /.well-known/x402.json`.
+- Choose the least expensive model or media tier that satisfies the task.
+- Keep search limits, history windows, and generated media dimensions as small
+  as the task permits.
+- Reuse crypto identifiers and wallet metadata instead of repeating discovery
+  calls.
+- Use one targeted endpoint per task; avoid speculative paid calls across
+  multiple models.

--- a/providers/x402engine/gateway/openapi.json
+++ b/providers/x402engine/gateway/openapi.json
@@ -1,0 +1,10298 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "x402engine API",
+    "version": "3.0.0",
+    "description": "Pay-per-call API gateway for AI agents using HTTP 402 payments."
+  },
+  "servers": [
+    {
+      "url": "https://x402engine.app"
+    }
+  ],
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Check x402engine service health",
+        "tags": [
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "Service is healthy"
+          }
+        }
+      }
+    },
+    "/.well-known/x402.json": {
+      "get": {
+        "summary": "Fetch x402 service discovery catalog",
+        "tags": [
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "Machine-readable x402 service catalog"
+          }
+        }
+      }
+    },
+    "/.well-known/x402": {
+      "get": {
+        "summary": "Fetch x402 service discovery alias",
+        "tags": [
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "Machine-readable x402 service catalog"
+          }
+        }
+      }
+    },
+    "/api/services": {
+      "get": {
+        "summary": "List available x402engine services",
+        "tags": [
+          "discovery"
+        ],
+        "responses": {
+          "200": {
+            "description": "Available x402engine services"
+          }
+        }
+      }
+    },
+    "/api/image/fast": {
+      "post": {
+        "summary": "Run Fast Image Generation via image-fast API",
+        "description": "Quick image generation using FLUX Schnell (~2s, good for drafts)",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "image-fast",
+        "x-price": "$0.015",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.015",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "15000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.015",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "15000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.015",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "15000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text description of image to generate",
+                    "example": "a red sports car"
+                  },
+                  "width": {
+                    "type": "number",
+                    "description": "Image width in pixels (256-2048)",
+                    "example": 1024,
+                    "default": 1024
+                  },
+                  "height": {
+                    "type": "number",
+                    "description": "Image height in pixels (256-2048)",
+                    "example": 1024,
+                    "default": 1024
+                  },
+                  "seed": {
+                    "type": "number",
+                    "description": "Random seed for reproducibility",
+                    "example": 42
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/image/quality": {
+      "post": {
+        "summary": "Run Quality Image Generation via image-quality API",
+        "description": "High-quality image generation using FLUX.2 Pro (~5s, production-ready)",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "image-quality",
+        "x-price": "$0.05",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.05",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "50000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.05",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "50000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.05",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "50000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text description of image to generate",
+                    "example": "a sunset over mountains"
+                  },
+                  "width": {
+                    "type": "number",
+                    "description": "Image width in pixels (256-2048)",
+                    "example": 1024,
+                    "default": 1024
+                  },
+                  "height": {
+                    "type": "number",
+                    "description": "Image height in pixels (256-2048)",
+                    "example": 1024,
+                    "default": 1024
+                  },
+                  "seed": {
+                    "type": "number",
+                    "description": "Random seed for reproducibility",
+                    "example": 42
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/image/text": {
+      "post": {
+        "summary": "Run Text-in-Image Generation via image-text API",
+        "description": "Image generation with accurate text rendering using Ideogram v3 (best for logos, signage)",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "image-text",
+        "x-price": "$0.12",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.12",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "120000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.12",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "120000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.12",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "120000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text description including text to render",
+                    "example": "a logo with the text \"ACME\""
+                  },
+                  "image_size": {
+                    "type": "string",
+                    "description": "Output size",
+                    "example": "square",
+                    "default": "square"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/image/face-swap": {
+      "post": {
+        "summary": "Run Face Swap via face-swap API",
+        "description": "Identity-preserving face swap using FLUX PuLID for portraits, product shots, and stylized edits",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "face-swap",
+        "x-price": "$0.08",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "80000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "80000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "80000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Describe the final image after the face swap",
+                    "example": "a studio portrait with natural skin tones and soft cinematic lighting"
+                  },
+                  "reference_image_url": {
+                    "type": "string",
+                    "description": "Public image URL containing the source face to preserve",
+                    "example": "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=1024"
+                  },
+                  "width": {
+                    "type": "number",
+                    "description": "Image width in pixels (256-2048)",
+                    "example": 1024,
+                    "default": 1024
+                  },
+                  "height": {
+                    "type": "number",
+                    "description": "Image height in pixels (256-2048)",
+                    "example": 1024,
+                    "default": 1024
+                  },
+                  "seed": {
+                    "type": "number",
+                    "description": "Random seed for reproducibility",
+                    "example": 7
+                  },
+                  "negative_prompt": {
+                    "type": "string",
+                    "description": "What to avoid in the final image",
+                    "example": "blur, warped eyes, extra fingers"
+                  },
+                  "guidance_scale": {
+                    "type": "number",
+                    "description": "Prompt guidance strength",
+                    "example": 4
+                  },
+                  "id_weight": {
+                    "type": "number",
+                    "description": "How strongly to preserve identity from the reference face",
+                    "example": 1.2
+                  }
+                },
+                "required": [
+                  "prompt",
+                  "reference_image_url"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/image/nano-banana": {
+      "post": {
+        "summary": "Run Nano Banana 2 Image Generation via image-nano-banana API",
+        "description": "Google's fast, high-quality image generation with aspect ratio control and optional web search",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "image-nano-banana",
+        "x-price": "$0.10",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "100000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "100000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "100000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Text description of image to generate (up to 50,000 chars)",
+                    "example": "a cyberpunk cityscape at sunset with neon signs"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Output aspect ratio (auto, 21:9, 16:9, 3:2, 4:3, 5:4, 1:1, 4:5, 3:4, 2:3, 9:16)",
+                    "example": "16:9",
+                    "default": "1:1"
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "description": "Image format: png, jpeg, or webp",
+                    "example": "png",
+                    "default": "png"
+                  },
+                  "seed": {
+                    "type": "number",
+                    "description": "Random seed for reproducibility",
+                    "example": 42
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/fast": {
+      "post": {
+        "summary": "Run Fast Video Generation via video-fast API",
+        "description": "Generate a 5-second video with Kling V3 Standard in landscape, portrait, or square format",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "video-fast",
+        "x-price": "$0.55",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.55",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "550000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.55",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "550000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.55",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "550000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Describe the scene, motion, and camera direction",
+                    "example": "A cinematic drone shot rising over a misty mountain valley at sunrise"
+                  },
+                  "duration": {
+                    "type": "string",
+                    "description": "Fixed video duration",
+                    "example": "5",
+                    "default": "5"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Output aspect ratio: 16:9, 9:16, or 1:1",
+                    "example": "16:9",
+                    "default": "16:9"
+                  },
+                  "negative_prompt": {
+                    "type": "string",
+                    "description": "Visual qualities or artifacts to avoid",
+                    "example": "blur, distortion, low quality"
+                  },
+                  "generate_audio": {
+                    "type": "boolean",
+                    "description": "Audio generation is fixed off for deterministic per-call pricing",
+                    "example": false,
+                    "default": false
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/quality": {
+      "post": {
+        "summary": "Run Quality Video Generation via video-quality API",
+        "description": "Generate a production-quality 5-second video with Kling V3 Pro",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "video-quality",
+        "x-price": "$0.70",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.70",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "700000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.70",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "700000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.70",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "700000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Describe the scene, motion, and camera direction",
+                    "example": "Close-up of glowing fireflies moving through a forest at twilight, shallow depth of field"
+                  },
+                  "duration": {
+                    "type": "string",
+                    "description": "Fixed video duration",
+                    "example": "5",
+                    "default": "5"
+                  },
+                  "aspect_ratio": {
+                    "type": "string",
+                    "description": "Output aspect ratio: 16:9, 9:16, or 1:1",
+                    "example": "16:9",
+                    "default": "16:9"
+                  },
+                  "negative_prompt": {
+                    "type": "string",
+                    "description": "Visual qualities or artifacts to avoid",
+                    "example": "blur, distortion, low quality"
+                  },
+                  "generate_audio": {
+                    "type": "boolean",
+                    "description": "Audio generation is fixed off for deterministic per-call pricing",
+                    "example": false,
+                    "default": false
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/hailuo": {
+      "post": {
+        "summary": "Run Hailuo Video Generation via video-hailuo API",
+        "description": "Generate a cinematic 1080p video with MiniMax Hailuo 2.3 Pro",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "video-hailuo",
+        "x-price": "$0.65",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.65",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "650000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.65",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "650000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.65",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "650000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Detailed video prompt including subject motion and camera direction",
+                    "example": "A snowboarder carving through deep powder while the camera follows from behind"
+                  }
+                },
+                "required": [
+                  "prompt"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/video/animate": {
+      "post": {
+        "summary": "Run Image to Video Animation via video-animate API",
+        "description": "Animate a public image into a 5-second video with Kling V3 Pro",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "video-animate",
+        "x-price": "$0.70",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.70",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "700000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.70",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "700000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.70",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "700000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "prompt": {
+                    "type": "string",
+                    "description": "Describe the motion and camera direction to apply to the image",
+                    "example": "Slow cinematic push-in while warm light moves across the scene"
+                  },
+                  "image_url": {
+                    "type": "string",
+                    "description": "Public HTTP or HTTPS image URL to use as the first frame",
+                    "example": "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=1280"
+                  },
+                  "duration": {
+                    "type": "string",
+                    "description": "Fixed video duration",
+                    "example": "5",
+                    "default": "5"
+                  },
+                  "negative_prompt": {
+                    "type": "string",
+                    "description": "Visual qualities or artifacts to avoid",
+                    "example": "blur, distortion, low quality"
+                  },
+                  "generate_audio": {
+                    "type": "boolean",
+                    "description": "Audio generation is fixed off for deterministic per-call pricing",
+                    "example": false,
+                    "default": false
+                  }
+                },
+                "required": [
+                  "prompt",
+                  "image_url"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tts/lux": {
+      "post": {
+        "summary": "Run Lux Voice Cloning TTS via tts-lux API",
+        "description": "Voice-cloning text-to-speech — provide a reference audio clip and generate speech in that voice at 48kHz",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "tts-lux",
+        "x-price": "$0.02",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "20000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "20000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "20000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "Text to convert to speech",
+                    "example": "Hey, what's up? I'm feeling really great today!"
+                  },
+                  "audio_url": {
+                    "type": "string",
+                    "description": "URL of reference audio file for voice cloning",
+                    "example": "https://storage.googleapis.com/falserverless/example_inputs/reference_audio.wav"
+                  },
+                  "num_inference_steps": {
+                    "type": "number",
+                    "description": "Flow-matching inference steps (1-16)",
+                    "example": 4,
+                    "default": 4
+                  },
+                  "guidance_scale": {
+                    "type": "number",
+                    "description": "Classifier-free guidance scale (0-10)",
+                    "example": 3,
+                    "default": 3
+                  },
+                  "max_ref_length": {
+                    "type": "number",
+                    "description": "Max reference audio duration in seconds (1-15)",
+                    "example": 5,
+                    "default": 5
+                  },
+                  "seed": {
+                    "type": "number",
+                    "description": "Random seed for reproducibility"
+                  }
+                },
+                "required": [
+                  "text",
+                  "audio_url"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/code/run": {
+      "post": {
+        "summary": "Run Code Execution via code-run API",
+        "description": "Run code in isolated sandbox — Python, JavaScript, Bash, R (up to 5 min)",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "code-run",
+        "x-price": "$0.005",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "5000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "5000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "5000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "description": "Code to execute",
+                    "example": "print(\"hello\")"
+                  },
+                  "language": {
+                    "type": "string",
+                    "description": "Programming language (python, javascript, bash, r)",
+                    "example": "python",
+                    "default": "python"
+                  },
+                  "timeout": {
+                    "type": "number",
+                    "description": "Execution timeout in seconds (1-300)",
+                    "example": 60,
+                    "default": 60
+                  }
+                },
+                "required": [
+                  "code"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/transcribe": {
+      "post": {
+        "summary": "Run Audio Transcription via transcribe API",
+        "description": "Convert audio to text with speaker identification — covers up to 10 minutes of audio",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "transcribe",
+        "x-price": "$0.10",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "100000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "100000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "100000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "audio_url": {
+                    "type": "string",
+                    "description": "URL of audio file to transcribe (provide audio_url OR audio_base64, not both)",
+                    "example": "https://example.com/audio.mp3"
+                  },
+                  "audio_base64": {
+                    "type": "string",
+                    "description": "Base64-encoded audio data with MIME type prefix (provide audio_url OR audio_base64, not both)",
+                    "example": "data:audio/mp3;base64,SGVsbG8="
+                  },
+                  "audio_mimetype": {
+                    "type": "string",
+                    "description": "MIME type when using audio_base64 (e.g. audio/mp3, audio/wav)",
+                    "example": "audio/mp3"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/crypto/price": {
+      "get": {
+        "summary": "Fetch Crypto Price Feed via crypto-price API",
+        "description": "Real-time cryptocurrency prices for any coin in any fiat currency",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "crypto-price",
+        "x-price": "$0.001",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "1000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "1000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "1000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "required": true,
+            "description": "Comma-separated coin IDs (e.g. bitcoin,ethereum)",
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated coin IDs (e.g. bitcoin,ethereum)",
+              "example": "bitcoin,ethereum"
+            },
+            "example": "bitcoin,ethereum"
+          },
+          {
+            "name": "currencies",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated fiat currencies",
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated fiat currencies",
+              "example": "usd,eur",
+              "default": "usd"
+            },
+            "example": "usd,eur"
+          },
+          {
+            "name": "include_24h_change",
+            "in": "query",
+            "required": false,
+            "description": "Include 24h price change",
+            "schema": {
+              "type": "boolean",
+              "description": "Include 24h price change",
+              "default": true
+            }
+          },
+          {
+            "name": "include_market_cap",
+            "in": "query",
+            "required": false,
+            "description": "Include market cap",
+            "schema": {
+              "type": "boolean",
+              "description": "Include market cap",
+              "default": false
+            }
+          }
+        ]
+      }
+    },
+    "/api/crypto/markets": {
+      "get": {
+        "summary": "Fetch Crypto Market Data via crypto-markets API",
+        "description": "Market rankings with price, volume, market cap — filterable by category",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "crypto-markets",
+        "x-price": "$0.002",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "2000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "2000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "2000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "currency",
+            "in": "query",
+            "required": false,
+            "description": "Fiat currency for pricing",
+            "schema": {
+              "type": "string",
+              "description": "Fiat currency for pricing",
+              "example": "usd",
+              "default": "usd"
+            },
+            "example": "usd"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "description": "Filter by category ID",
+            "schema": {
+              "type": "string",
+              "description": "Filter by category ID",
+              "example": "decentralized-finance-defi"
+            },
+            "example": "decentralized-finance-defi"
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order",
+            "schema": {
+              "type": "string",
+              "description": "Sort order",
+              "example": "market_cap_desc",
+              "default": "market_cap_desc"
+            },
+            "example": "market_cap_desc"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of results (1-250)",
+            "schema": {
+              "type": "number",
+              "description": "Number of results (1-250)",
+              "example": 100,
+              "default": 100
+            },
+            "example": 100
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number (1-500)",
+            "schema": {
+              "type": "number",
+              "description": "Page number (1-500)",
+              "example": 1,
+              "default": 1
+            },
+            "example": 1
+          }
+        ]
+      }
+    },
+    "/api/crypto/history": {
+      "get": {
+        "summary": "Fetch Crypto Historical Data via crypto-history API",
+        "description": "Historical price, market cap, and volume data for any coin",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "crypto-history",
+        "x-price": "$0.003",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "3000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "3000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "3000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "description": "Coin ID",
+            "schema": {
+              "type": "string",
+              "description": "Coin ID",
+              "example": "bitcoin"
+            },
+            "example": "bitcoin"
+          },
+          {
+            "name": "currency",
+            "in": "query",
+            "required": false,
+            "description": "Fiat currency",
+            "schema": {
+              "type": "string",
+              "description": "Fiat currency",
+              "example": "usd",
+              "default": "usd"
+            },
+            "example": "usd"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "description": "Days of history (1-365 or \"max\")",
+            "schema": {
+              "type": "string",
+              "description": "Days of history (1-365 or \"max\")",
+              "example": "30",
+              "default": "30"
+            },
+            "example": "30"
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "required": false,
+            "description": "Data interval (daily)",
+            "schema": {
+              "type": "string",
+              "description": "Data interval (daily)",
+              "example": "daily"
+            },
+            "example": "daily"
+          }
+        ]
+      }
+    },
+    "/api/crypto/trending": {
+      "get": {
+        "summary": "Fetch Trending Crypto via crypto-trending API",
+        "description": "Currently trending coins on CoinGecko",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "crypto-trending",
+        "x-price": "$0.001",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "1000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "1000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "1000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        }
+      }
+    },
+    "/api/crypto/search": {
+      "get": {
+        "summary": "Fetch Crypto Search via crypto-search API",
+        "description": "Search for a coin by name or symbol to get its CoinGecko ID",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "crypto-search",
+        "x-price": "$0.001",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "1000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "1000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "1000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query (coin name or symbol)",
+            "schema": {
+              "type": "string",
+              "description": "Search query (coin name or symbol)",
+              "example": "bitcoin"
+            },
+            "example": "bitcoin"
+          }
+        ]
+      }
+    },
+    "/api/wallet/balances": {
+      "post": {
+        "summary": "Run Wallet Balances via wallet-balances API",
+        "description": "Token balances for any wallet across 20+ chains — EVM, Solana, Bitcoin",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "wallet-balances",
+        "x-price": "$0.005",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "5000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "5000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "5000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "chain": {
+                    "type": "string",
+                    "description": "Chain name (ethereum, polygon, base, arbitrum, etc.)",
+                    "example": "ethereum"
+                  },
+                  "address": {
+                    "type": "string",
+                    "description": "Wallet address",
+                    "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                  }
+                },
+                "required": [
+                  "chain",
+                  "address"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/wallet/transactions": {
+      "post": {
+        "summary": "Run Wallet Transactions via wallet-transactions API",
+        "description": "Transaction history with asset transfers and labels for any wallet",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "wallet-transactions",
+        "x-price": "$0.005",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "5000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "5000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "5000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "type": "string",
+                    "description": "Wallet address",
+                    "example": "0x..."
+                  },
+                  "chain": {
+                    "type": "string",
+                    "description": "Chain name",
+                    "example": "ethereum"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Max results",
+                    "example": 100,
+                    "default": 100
+                  }
+                },
+                "required": [
+                  "address"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/wallet/pnl": {
+      "post": {
+        "summary": "Run Wallet PnL via wallet-pnl API",
+        "description": "Realized and unrealized profit & loss per token for any wallet",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "wallet-pnl",
+        "x-price": "$0.01",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "chain": {
+                    "type": "string",
+                    "description": "Chain name (ethereum, polygon, base, arbitrum, etc.)",
+                    "example": "ethereum"
+                  },
+                  "address": {
+                    "type": "string",
+                    "description": "Wallet address",
+                    "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                  }
+                },
+                "required": [
+                  "chain",
+                  "address"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/token/prices": {
+      "post": {
+        "summary": "Run Token Prices via token-prices API",
+        "description": "Real-time DEX-derived token prices with OHLC data — up to 200 tokens per request",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "token-prices",
+        "x-price": "$0.005",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "5000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "5000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "5000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tokens": {
+                    "type": "array",
+                    "description": "Array of token objects with chain and token_address",
+                    "example": [
+                      {
+                        "chain": "ethereum",
+                        "token_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "tokens"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/token/metadata": {
+      "get": {
+        "summary": "Fetch Token Metadata via token-metadata API",
+        "description": "Token/asset metadata — name, symbol, decimals, chain info",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "token-metadata",
+        "x-price": "$0.002",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "2000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "2000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "2000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "chain",
+            "in": "query",
+            "required": true,
+            "description": "Chain name",
+            "schema": {
+              "type": "string",
+              "description": "Chain name",
+              "example": "ethereum"
+            },
+            "example": "ethereum"
+          },
+          {
+            "name": "address",
+            "in": "query",
+            "required": true,
+            "description": "Token contract address",
+            "schema": {
+              "type": "string",
+              "description": "Token contract address",
+              "example": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+            },
+            "example": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+          }
+        ]
+      }
+    },
+    "/api/ipfs/pin": {
+      "post": {
+        "summary": "Run IPFS Pin via ipfs-pin API",
+        "description": "Pin JSON, files, or URLs to IPFS for decentralized storage",
+        "tags": [
+          "storage"
+        ],
+        "x-service-id": "ipfs-pin",
+        "x-price": "$0.01",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "json": {
+                    "type": "object",
+                    "description": "JSON object to pin (provide json OR url, not both)",
+                    "example": {
+                      "hello": "world"
+                    }
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "URL of file to pin (provide json OR url, not both)",
+                    "example": "https://example.com/file.jpg"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Base64-encoded file",
+                    "example": "data:image/png;base64,..."
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ipfs/get": {
+      "get": {
+        "summary": "Fetch IPFS Retrieve via ipfs-get API",
+        "description": "Fetch a file from IPFS by CID via gateway",
+        "tags": [
+          "storage"
+        ],
+        "x-service-id": "ipfs-get",
+        "x-price": "$0.001",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "1000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "1000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "1000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "cid",
+            "in": "query",
+            "required": true,
+            "description": "IPFS CID",
+            "schema": {
+              "type": "string",
+              "description": "IPFS CID",
+              "example": "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
+            },
+            "example": "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG"
+          }
+        ]
+      }
+    },
+    "/api/llm/gpt-4o": {
+      "post": {
+        "summary": "Run GPT-4o via llm-gpt-4o API",
+        "description": "OpenAI's flagship multimodal model — strong all-around for text, vision, and reasoning",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-4o",
+        "x-price": "$0.04",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "40000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "40000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "40000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-4o-mini": {
+      "post": {
+        "summary": "Run GPT-4o Mini via llm-gpt-4o-mini API",
+        "description": "Fast, affordable GPT-4o variant — great for simple tasks and high-volume use",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-4o-mini",
+        "x-price": "$0.003",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "3000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "3000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "3000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/o1": {
+      "post": {
+        "summary": "Run OpenAI o1 via llm-o1 API",
+        "description": "OpenAI's reasoning model — excels at math, science, coding, and multi-step problem solving",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-o1",
+        "x-price": "$0.03",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "30000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "30000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "30000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate (reasoning models use more)",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/claude-opus": {
+      "post": {
+        "summary": "Run Claude Opus 4.6 via llm-claude-opus API",
+        "description": "Anthropic's most powerful model — best for complex analysis, coding, and extended thinking",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-claude-opus",
+        "x-price": "$0.09",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.09",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "90000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.09",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "90000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.09",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "90000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/claude-sonnet": {
+      "post": {
+        "summary": "Run Claude Sonnet 4.5 via llm-claude-sonnet API",
+        "description": "Anthropic's balanced model — excellent coding, reasoning, and creative writing",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-claude-sonnet",
+        "x-price": "$0.06",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "60000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "60000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "60000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/claude-haiku": {
+      "post": {
+        "summary": "Run Claude Haiku 4.5 via llm-claude-haiku API",
+        "description": "Anthropic's fastest model — affordable and quick for simple tasks and high throughput",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-claude-haiku",
+        "x-price": "$0.02",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "20000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "20000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "20000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gemini-pro": {
+      "post": {
+        "summary": "Run Gemini 2.5 Pro via llm-gemini-pro API",
+        "description": "Google's most capable model — strong at reasoning, coding, and multimodal tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gemini-pro",
+        "x-price": "$0.035",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.035",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "35000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.035",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "35000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.035",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "35000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gemini-flash": {
+      "post": {
+        "summary": "Run Gemini 2.5 Flash via llm-gemini-flash API",
+        "description": "Google's fast model — great balance of speed, quality, and cost for everyday tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gemini-flash",
+        "x-price": "$0.009",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.009",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "9000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.009",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "9000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.009",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "9000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/deepseek": {
+      "post": {
+        "summary": "Run DeepSeek V3 via llm-deepseek API",
+        "description": "DeepSeek's flagship chat model — strong open-source reasoning and coding at low cost",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-deepseek",
+        "x-price": "$0.005",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "5000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "5000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "5000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/deepseek-r1": {
+      "post": {
+        "summary": "Run DeepSeek R1 via llm-deepseek-r1 API",
+        "description": "DeepSeek's reasoning model — chain-of-thought reasoning competitive with o3 at fraction of cost",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-deepseek-r1",
+        "x-price": "$0.01",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/llama": {
+      "post": {
+        "summary": "Run Llama 3.3 70B via llm-llama API",
+        "description": "Meta's open-source model — great general-purpose performance at very low cost",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-llama",
+        "x-price": "$0.002",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "2000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "2000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "2000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/grok": {
+      "post": {
+        "summary": "Run Grok 4.3 via llm-grok API",
+        "description": "xAI's current Grok 4 route — strong reasoning and real-time knowledge",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-grok",
+        "x-price": "$0.06",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "60000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "60000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "60000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/qwen": {
+      "post": {
+        "summary": "Run Qwen3 235B via llm-qwen API",
+        "description": "Alibaba's flagship open model — excellent multilingual and coding capabilities",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-qwen",
+        "x-price": "$0.004",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.004",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "4000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.004",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "4000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.004",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "4000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/mistral": {
+      "post": {
+        "summary": "Run Mistral Large 3 via llm-mistral API",
+        "description": "Mistral's flagship model — strong European AI with great multilingual support",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-mistral",
+        "x-price": "$0.006",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "6000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "6000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "6000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/perplexity": {
+      "post": {
+        "summary": "Run Perplexity Sonar Pro via llm-perplexity API",
+        "description": "Search-augmented LLM — answers grounded in real-time web search with citations",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-perplexity",
+        "x-price": "$0.06",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "60000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "60000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "60000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.2": {
+      "post": {
+        "summary": "Run GPT-5.2 via llm-gpt-5.2 API",
+        "description": "OpenAI's latest flagship model — top-tier reasoning, coding, and multimodal capabilities",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.2",
+        "x-price": "$0.08",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "80000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "80000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "80000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.2-codex": {
+      "post": {
+        "summary": "Run GPT-5.2 Codex via llm-gpt-5.2-codex API",
+        "description": "OpenAI's code-specialized reasoning model — optimized for software engineering tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.2-codex",
+        "x-price": "$0.06",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "60000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "60000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "60000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate (reasoning models use more)",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/kimi": {
+      "post": {
+        "summary": "Run Kimi K2.5 via llm-kimi API",
+        "description": "Moonshot AI's flagship model — strong reasoning and long-context capabilities",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-kimi",
+        "x-price": "$0.03",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "30000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "30000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "30000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/minimax": {
+      "post": {
+        "summary": "Run MiniMax M2.5 via llm-minimax API",
+        "description": "MiniMax's efficient model — fast and affordable for everyday tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-minimax",
+        "x-price": "$0.01",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/glm": {
+      "post": {
+        "summary": "Run GLM-5 via llm-glm API",
+        "description": "Zhipu AI's flagship model — strong multilingual and reasoning performance",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-glm",
+        "x-price": "$0.03",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "30000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "30000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "30000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/grok-code": {
+      "post": {
+        "summary": "Run Grok Build 0.1 via llm-grok-code API",
+        "description": "xAI's build-focused model — code generation, analysis, and agentic implementation work",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-grok-code",
+        "x-price": "$0.04",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "40000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "40000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "40000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/seed": {
+      "post": {
+        "summary": "Run Seed 1.6 via llm-seed API",
+        "description": "ByteDance's flagship model — competitive reasoning and generation at low cost",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-seed",
+        "x-price": "$0.02",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "20000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "20000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "20000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/devstral": {
+      "post": {
+        "summary": "Run Devstral 2 via llm-devstral API",
+        "description": "Mistral's code-focused model — optimized for software development and technical tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-devstral",
+        "x-price": "$0.02",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "20000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "20000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "20000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/deepseek-v3.2": {
+      "post": {
+        "summary": "Run DeepSeek V3.2 via llm-deepseek-v3.2 API",
+        "description": "DeepSeek's latest flagship model — improved reasoning and coding over V3 at same low cost",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-deepseek-v3.2",
+        "x-price": "$0.005",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "5000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "5000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "5000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gemini-3-pro": {
+      "post": {
+        "summary": "Run Gemini 3.1 Pro via llm-gemini-3-pro API",
+        "description": "Google's Gemini 3.1 Pro Preview on the Gemini Pro compatibility route — advanced reasoning, coding, and multimodal understanding",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gemini-3-pro",
+        "x-price": "$0.045",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.045",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "45000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.045",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "45000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.045",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "45000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gemini-3-flash": {
+      "post": {
+        "summary": "Run Gemini 3 Flash via llm-gemini-3-flash API",
+        "description": "Google's next-gen flash model — fast and efficient for everyday tasks with improved quality",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gemini-3-flash",
+        "x-price": "$0.012",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "12000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "12000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "12000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/claude-sonnet-4.6": {
+      "post": {
+        "summary": "Run Claude Sonnet 4.6 via llm-claude-sonnet-4.6 API",
+        "description": "Anthropic's latest balanced model — excellent coding, reasoning, and creative writing",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-claude-sonnet-4.6",
+        "x-price": "$0.06",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "60000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "60000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.06",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "60000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.2-pro": {
+      "post": {
+        "summary": "Run GPT-5.2 Pro via llm-gpt-5.2-pro API",
+        "description": "OpenAI's premium reasoning model — extended thinking for complex math, science, and coding problems",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.2-pro",
+        "x-price": "$0.25",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.25",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "250000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.25",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "250000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.25",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "250000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate (reasoning models use more)",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/qwen-coder": {
+      "post": {
+        "summary": "Run Qwen3 Coder via llm-qwen-coder API",
+        "description": "Alibaba's code-specialized model — optimized for code generation, review, and technical tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-qwen-coder",
+        "x-price": "$0.004",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.004",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "4000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.004",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "4000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.004",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "4000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.1": {
+      "post": {
+        "summary": "Run GPT-5.1 via llm-gpt-5.1 API",
+        "description": "OpenAI's efficient flagship model — strong all-around performance at lower cost than GPT-5.2",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.1",
+        "x-price": "$0.035",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.035",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "35000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.035",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "35000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.035",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "35000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.4": {
+      "post": {
+        "summary": "Run GPT-5.4 via llm-gpt-5.4 API",
+        "description": "OpenAI's unified flagship model — 1M context, computer use, top-tier across all tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.4",
+        "x-price": "$0.10",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "100000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "100000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "100000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.4-pro": {
+      "post": {
+        "summary": "Run GPT-5.4 Pro via llm-gpt-5.4-pro API",
+        "description": "OpenAI's max reasoning tier — extended thinking for complex analysis, math, and coding",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.4-pro",
+        "x-price": "$0.30",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.30",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "300000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.30",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "300000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.30",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "300000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.3-codex": {
+      "post": {
+        "summary": "Run GPT-5.3 Codex via llm-gpt-5.3-codex API",
+        "description": "OpenAI's SOTA agentic coding model — best-in-class for software engineering and code generation",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.3-codex",
+        "x-price": "$0.08",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "80000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "80000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "80000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/claude-opus-4.5": {
+      "post": {
+        "summary": "Run Claude Opus 4.5 via llm-claude-opus-4.5 API",
+        "description": "Anthropic's previous-gen Opus — strong reasoning and creative writing, large context window",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-claude-opus-4.5",
+        "x-price": "$0.09",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.09",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "90000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.09",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "90000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.09",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "90000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gemini-3.1-pro": {
+      "post": {
+        "summary": "Run Gemini 3.1 Pro via llm-gemini-3.1-pro API",
+        "description": "Google's latest flagship — advanced reasoning, coding, and multimodal with extended thinking",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gemini-3.1-pro",
+        "x-price": "$0.05",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.05",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "50000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.05",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "50000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.05",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "50000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gemini-3.1-flash-lite": {
+      "post": {
+        "summary": "Run Gemini 3.1 Flash Lite via llm-gemini-3.1-flash-lite API",
+        "description": "Google's fastest and cheapest model — ideal for high-volume, low-latency tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gemini-3.1-flash-lite",
+        "x-price": "$0.003",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "3000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "3000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "3000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/qwen3.5": {
+      "post": {
+        "summary": "Run Qwen 3.5 via llm-qwen3.5 API",
+        "description": "Alibaba's latest model — 1M context, strong multilingual and coding capabilities",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-qwen3.5",
+        "x-price": "$0.006",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "6000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "6000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "6000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/deepseek-v3.2-speciale": {
+      "post": {
+        "summary": "Run DeepSeek V3.2 via llm-deepseek-v3.2-speciale API",
+        "description": "DeepSeek V3.2 served on the Speciale compatibility route — strong reasoning and coding at low cost",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-deepseek-v3.2-speciale",
+        "x-price": "$0.008",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.008",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "8000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.008",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "8000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.008",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "8000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/embeddings": {
+      "post": {
+        "summary": "Run Text Embeddings via embeddings API",
+        "description": "Generate text embeddings using OpenAI text-embedding-3-small — for semantic search, clustering, RAG",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "embeddings",
+        "x-price": "$0.001",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "1000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "1000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "1000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "Single text to embed",
+                    "example": "hello world"
+                  },
+                  "texts": {
+                    "type": "array",
+                    "description": "Array of texts to embed (1-100)",
+                    "example": [
+                      "hello",
+                      "world"
+                    ]
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/web/scrape": {
+      "get": {
+        "summary": "Fetch Web Scrape via web-scrape API",
+        "description": "Scrape any URL and get clean markdown content — ideal for extracting readable text from web pages",
+        "tags": [
+          "web"
+        ],
+        "x-service-id": "web-scrape",
+        "x-price": "$0.005",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "5000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "5000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "5000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "URL to scrape",
+            "schema": {
+              "type": "string",
+              "description": "URL to scrape",
+              "example": "https://example.com"
+            },
+            "example": "https://example.com"
+          }
+        ]
+      }
+    },
+    "/api/web/screenshot": {
+      "get": {
+        "summary": "Fetch Web Screenshot via web-screenshot API",
+        "description": "Capture a screenshot of any URL — returns base64-encoded image, supports full-page capture",
+        "tags": [
+          "web"
+        ],
+        "x-service-id": "web-screenshot",
+        "x-price": "$0.01",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "URL to screenshot",
+            "schema": {
+              "type": "string",
+              "description": "URL to screenshot",
+              "example": "https://example.com"
+            },
+            "example": "https://example.com"
+          },
+          {
+            "name": "fullPage",
+            "in": "query",
+            "required": false,
+            "description": "Capture full page",
+            "schema": {
+              "type": "boolean",
+              "description": "Capture full page",
+              "default": false
+            }
+          }
+        ]
+      }
+    },
+    "/api/search/web": {
+      "post": {
+        "summary": "Run Web Search via search-web API",
+        "description": "Neural web search with highlighted snippets — find articles, news, research, and any web content",
+        "tags": [
+          "web"
+        ],
+        "x-service-id": "search-web",
+        "x-price": "$0.010",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.010",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.010",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.010",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "description": "Search query",
+                    "example": "latest ethereum news"
+                  },
+                  "numResults": {
+                    "type": "number",
+                    "description": "Number of results (1-30)",
+                    "example": 10,
+                    "default": 10
+                  },
+                  "includeDomains": {
+                    "type": "array",
+                    "description": "Only include results from these domains",
+                    "example": [
+                      "arxiv.org",
+                      "github.com"
+                    ]
+                  },
+                  "category": {
+                    "type": "string",
+                    "description": "Content category filter (news, research paper, company, tweet, github, pdf)",
+                    "example": "news"
+                  },
+                  "includeText": {
+                    "type": "boolean",
+                    "description": "Include full page text in results",
+                    "default": false
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/search/contents": {
+      "post": {
+        "summary": "Run Web Content Fetch via search-contents API",
+        "description": "Fetch full text content from URLs — extract clean text from up to 10 pages at once",
+        "tags": [
+          "web"
+        ],
+        "x-service-id": "search-contents",
+        "x-price": "$0.005",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "5000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "5000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "5000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "urls": {
+                    "type": "array",
+                    "description": "Array of URLs to fetch content from (max 10)",
+                    "example": [
+                      "https://example.com/article"
+                    ]
+                  }
+                },
+                "required": [
+                  "urls"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tts/openai": {
+      "post": {
+        "summary": "Run Text-to-Speech (OpenAI) via tts-openai API",
+        "description": "Convert text to natural speech using OpenAI TTS — 6 voices, HD quality option, multiple audio formats",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "tts-openai",
+        "x-price": "$0.01",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "Text to convert to speech",
+                    "example": "Hello world"
+                  },
+                  "voice": {
+                    "type": "string",
+                    "description": "Voice ID (alloy, echo, fable, onyx, nova, shimmer)",
+                    "example": "alloy",
+                    "default": "alloy"
+                  },
+                  "model": {
+                    "type": "string",
+                    "description": "TTS model (tts-1, tts-1-hd)",
+                    "example": "tts-1",
+                    "default": "tts-1"
+                  }
+                },
+                "required": [
+                  "text"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tts/elevenlabs": {
+      "post": {
+        "summary": "Run Text-to-Speech (ElevenLabs) via tts-elevenlabs API",
+        "description": "Premium text-to-speech with ElevenLabs — ultra-realistic voices, multilingual support, custom voice IDs",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "tts-elevenlabs",
+        "x-price": "$0.02",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "20000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "20000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "20000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string",
+                    "description": "Text to convert to speech",
+                    "example": "Hello world"
+                  },
+                  "voice_id": {
+                    "type": "string",
+                    "description": "ElevenLabs voice ID",
+                    "example": "21m00Tcm4TlvDq8ikWAM"
+                  }
+                },
+                "required": [
+                  "text"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/ens/resolve": {
+      "get": {
+        "summary": "Fetch ENS Resolve via ens-resolve API",
+        "description": "Resolve an ENS name to an Ethereum address",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "ens-resolve",
+        "x-price": "$0.001",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "1000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "1000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "1000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "ENS name to resolve",
+            "schema": {
+              "type": "string",
+              "description": "ENS name to resolve",
+              "example": "vitalik.eth"
+            },
+            "example": "vitalik.eth"
+          }
+        ]
+      }
+    },
+    "/api/ens/reverse": {
+      "get": {
+        "summary": "Fetch ENS Reverse Lookup via ens-reverse API",
+        "description": "Reverse-resolve an Ethereum address to its ENS name",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "ens-reverse",
+        "x-price": "$0.001",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "1000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "1000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.001",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "1000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "address",
+            "in": "query",
+            "required": true,
+            "description": "Ethereum address (0x...)",
+            "schema": {
+              "type": "string",
+              "description": "Ethereum address (0x...)",
+              "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+            },
+            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          }
+        ]
+      }
+    },
+    "/api/tx/simulate": {
+      "post": {
+        "summary": "Run Transaction Simulation via tx-simulate API",
+        "description": "Simulate EVM transactions before sending — get gas estimates, execution traces, and revert reasons",
+        "tags": [
+          "crypto"
+        ],
+        "x-service-id": "tx-simulate",
+        "x-price": "$0.01",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "network_id": {
+                    "type": "string",
+                    "description": "Network ID (1=mainnet, 8453=Base, 10=Optimism, etc.)",
+                    "example": "1"
+                  },
+                  "from": {
+                    "type": "string",
+                    "description": "Sender address",
+                    "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                  },
+                  "to": {
+                    "type": "string",
+                    "description": "Recipient/contract address",
+                    "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "ETH value in wei",
+                    "example": "0"
+                  },
+                  "data": {
+                    "type": "string",
+                    "description": "Transaction calldata (hex string)"
+                  },
+                  "gas": {
+                    "type": "number",
+                    "description": "Gas limit"
+                  }
+                },
+                "required": [
+                  "network_id",
+                  "from",
+                  "to"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/travel/flights": {
+      "get": {
+        "summary": "Fetch Flight Search via travel-flights API",
+        "description": "Search flights via Google Flights (SerpApi). Returns best flights, prices, airlines, and price insights.",
+        "tags": [
+          "travel"
+        ],
+        "x-service-id": "travel-flights",
+        "x-price": "$0.02",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "20000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "20000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "20000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "origin",
+            "in": "query",
+            "required": true,
+            "description": "Departure airport IATA code",
+            "schema": {
+              "type": "string",
+              "description": "Departure airport IATA code",
+              "example": "JFK"
+            },
+            "example": "JFK"
+          },
+          {
+            "name": "destination",
+            "in": "query",
+            "required": true,
+            "description": "Arrival airport IATA code",
+            "schema": {
+              "type": "string",
+              "description": "Arrival airport IATA code",
+              "example": "LAX"
+            },
+            "example": "LAX"
+          },
+          {
+            "name": "departureDate",
+            "in": "query",
+            "required": true,
+            "description": "Departure date (YYYY-MM-DD)",
+            "schema": {
+              "type": "string",
+              "description": "Departure date (YYYY-MM-DD)",
+              "example": "2026-04-15"
+            },
+            "example": "2026-04-15"
+          },
+          {
+            "name": "returnDate",
+            "in": "query",
+            "required": false,
+            "description": "Return date for round trips (YYYY-MM-DD)",
+            "schema": {
+              "type": "string",
+              "description": "Return date for round trips (YYYY-MM-DD)"
+            }
+          },
+          {
+            "name": "adults",
+            "in": "query",
+            "required": false,
+            "description": "Number of adult passengers",
+            "schema": {
+              "type": "string",
+              "description": "Number of adult passengers",
+              "default": "1"
+            }
+          },
+          {
+            "name": "children",
+            "in": "query",
+            "required": false,
+            "description": "Number of children",
+            "schema": {
+              "type": "string",
+              "description": "Number of children"
+            }
+          },
+          {
+            "name": "travelClass",
+            "in": "query",
+            "required": false,
+            "description": "1=Economy, 2=Premium Economy, 3=Business, 4=First",
+            "schema": {
+              "type": "string",
+              "description": "1=Economy, 2=Premium Economy, 3=Business, 4=First",
+              "default": "1"
+            }
+          },
+          {
+            "name": "stops",
+            "in": "query",
+            "required": false,
+            "description": "0=Nonstop only, 1=Up to 1 stop, 2=Up to 2 stops",
+            "schema": {
+              "type": "string",
+              "description": "0=Nonstop only, 1=Up to 1 stop, 2=Up to 2 stops"
+            }
+          },
+          {
+            "name": "maxPrice",
+            "in": "query",
+            "required": false,
+            "description": "Maximum price filter",
+            "schema": {
+              "type": "string",
+              "description": "Maximum price filter"
+            }
+          },
+          {
+            "name": "currency",
+            "in": "query",
+            "required": false,
+            "description": "Currency code (e.g. USD, EUR)",
+            "schema": {
+              "type": "string",
+              "description": "Currency code (e.g. USD, EUR)",
+              "default": "USD"
+            }
+          }
+        ]
+      }
+    },
+    "/api/travel/hotels": {
+      "get": {
+        "summary": "Fetch Hotel Search via travel-hotels API",
+        "description": "Search hotels via Google Hotels (SerpApi). Returns properties with prices, ratings, and amenities.",
+        "tags": [
+          "travel"
+        ],
+        "x-service-id": "travel-hotels",
+        "x-price": "$0.02",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "20000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "20000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "20000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query — city name or hotel name",
+            "schema": {
+              "type": "string",
+              "description": "Search query — city name or hotel name",
+              "example": "hotels in Paris"
+            },
+            "example": "hotels in Paris"
+          },
+          {
+            "name": "checkInDate",
+            "in": "query",
+            "required": true,
+            "description": "Check-in date (YYYY-MM-DD)",
+            "schema": {
+              "type": "string",
+              "description": "Check-in date (YYYY-MM-DD)",
+              "example": "2026-04-15"
+            },
+            "example": "2026-04-15"
+          },
+          {
+            "name": "checkOutDate",
+            "in": "query",
+            "required": true,
+            "description": "Check-out date (YYYY-MM-DD)",
+            "schema": {
+              "type": "string",
+              "description": "Check-out date (YYYY-MM-DD)",
+              "example": "2026-04-18"
+            },
+            "example": "2026-04-18"
+          },
+          {
+            "name": "adults",
+            "in": "query",
+            "required": false,
+            "description": "Number of adults",
+            "schema": {
+              "type": "string",
+              "description": "Number of adults",
+              "default": "2"
+            }
+          },
+          {
+            "name": "children",
+            "in": "query",
+            "required": false,
+            "description": "Number of children",
+            "schema": {
+              "type": "string",
+              "description": "Number of children"
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "required": false,
+            "description": "3=Lowest price, 8=Highest rating, 13=Most reviewed",
+            "schema": {
+              "type": "string",
+              "description": "3=Lowest price, 8=Highest rating, 13=Most reviewed"
+            }
+          },
+          {
+            "name": "minPrice",
+            "in": "query",
+            "required": false,
+            "description": "Minimum price per night",
+            "schema": {
+              "type": "string",
+              "description": "Minimum price per night"
+            }
+          },
+          {
+            "name": "maxPrice",
+            "in": "query",
+            "required": false,
+            "description": "Maximum price per night",
+            "schema": {
+              "type": "string",
+              "description": "Maximum price per night"
+            }
+          },
+          {
+            "name": "hotelClass",
+            "in": "query",
+            "required": false,
+            "description": "Star rating (2-5)",
+            "schema": {
+              "type": "string",
+              "description": "Star rating (2-5)"
+            }
+          },
+          {
+            "name": "currency",
+            "in": "query",
+            "required": false,
+            "description": "Currency code (e.g. USD, EUR)",
+            "schema": {
+              "type": "string",
+              "description": "Currency code (e.g. USD, EUR)",
+              "default": "USD"
+            }
+          }
+        ]
+      }
+    },
+    "/api/llm/minimax-m2.7": {
+      "post": {
+        "summary": "Run MiniMax M2.7 via llm-minimax-m2.7 API",
+        "description": "MiniMax's latest model — improved reasoning and generation with 204k context",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-minimax-m2.7",
+        "x-price": "$0.01",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/llama-4-maverick": {
+      "post": {
+        "summary": "Run Llama 4 Maverick via llm-llama-4-maverick API",
+        "description": "Meta's latest open model — 1M context, strong multilingual and reasoning at very low cost",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-llama-4-maverick",
+        "x-price": "$0.003",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "3000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "3000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "3000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5-nano": {
+      "post": {
+        "summary": "Run GPT-5 Nano via llm-gpt-5-nano API",
+        "description": "OpenAI's cheapest GPT-5 tier — ultra-affordable for high-volume agent tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5-nano",
+        "x-price": "$0.002",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "2000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "2000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "2000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/o4-mini": {
+      "post": {
+        "summary": "Run OpenAI o4-mini via llm-o4-mini API",
+        "description": "OpenAI's latest small reasoning model — fast chain-of-thought for math, coding, and analysis",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-o4-mini",
+        "x-price": "$0.03",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "30000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "30000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "30000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/command-a": {
+      "post": {
+        "summary": "Run Cohere Command A via llm-command-a API",
+        "description": "Cohere's flagship model — 256k context, strong for enterprise RAG and structured generation",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-command-a",
+        "x-price": "$0.04",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "40000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "40000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "40000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/claude-opus-4.8": {
+      "post": {
+        "summary": "Run Claude Opus 4.8 via llm-claude-opus-4.8 API",
+        "description": "Anthropic's latest Opus model — premium analysis, coding, and long-context autonomous work",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-claude-opus-4.8",
+        "x-price": "$0.09",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.09",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "90000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.09",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "90000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.09",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "90000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/qwen3.7-plus": {
+      "post": {
+        "summary": "Run Qwen 3.7 Plus via llm-qwen3.7-plus API",
+        "description": "Alibaba's cost-effective Qwen 3.7 model — 1M context with strong coding and multilingual support",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-qwen3.7-plus",
+        "x-price": "$0.006",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "6000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "6000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "6000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/qwen3.7-max": {
+      "post": {
+        "summary": "Run Qwen 3.7 Max via llm-qwen3.7-max API",
+        "description": "Alibaba's flagship Qwen 3.7 model — 1M context for agent-centric coding and productivity tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-qwen3.7-max",
+        "x-price": "$0.015",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.015",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "15000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.015",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "15000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.015",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "15000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/glm-5.2": {
+      "post": {
+        "summary": "Run GLM 5.2 via llm-glm-5.2 API",
+        "description": "Z.ai's large-scale reasoning model — 1M context for long-horizon agent workflows and software engineering",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-glm-5.2",
+        "x-price": "$0.03",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "30000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "30000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "30000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/deepseek-v4-flash": {
+      "post": {
+        "summary": "Run DeepSeek V4 Flash via llm-deepseek-v4-flash API",
+        "description": "DeepSeek's low-latency V4 model — ultra-low-cost reasoning and coding with 1M context",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-deepseek-v4-flash",
+        "x-price": "$0.003",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "3000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "3000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "3000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/deepseek-v4-pro": {
+      "post": {
+        "summary": "Run DeepSeek V4 Pro via llm-deepseek-v4-pro API",
+        "description": "DeepSeek's stronger V4 model — advanced reasoning, coding, and long-context analysis",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-deepseek-v4-pro",
+        "x-price": "$0.006",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "6000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "6000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "6000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/minimax-m3": {
+      "post": {
+        "summary": "Run MiniMax M3 via llm-minimax-m3 API",
+        "description": "MiniMax's multimodal foundation model — 1M context for agentic work, coding, and long-document tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-minimax-m3",
+        "x-price": "$0.01",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "10000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "10000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.01",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "10000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.6-luna": {
+      "post": {
+        "summary": "Run GPT-5.6 Luna via llm-gpt-5.6-luna API",
+        "description": "OpenAI's efficient GPT-5.6 tier with a 1M-token context window",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.6-luna",
+        "x-price": "$0.02",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "20000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "20000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "20000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate (reasoning models use more)",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.6-luna-pro": {
+      "post": {
+        "summary": "Run GPT-5.6 Luna Pro via llm-gpt-5.6-luna-pro API",
+        "description": "OpenAI's higher-compute Luna tier for efficient long-context reasoning",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.6-luna-pro",
+        "x-price": "$0.04",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "40000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "40000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "40000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate (reasoning models use more)",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.6-terra": {
+      "post": {
+        "summary": "Run GPT-5.6 Terra via llm-gpt-5.6-terra API",
+        "description": "OpenAI's balanced GPT-5.6 tier for advanced reasoning and agent workflows",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.6-terra",
+        "x-price": "$0.04",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "40000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "40000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "40000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate (reasoning models use more)",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.6-terra-pro": {
+      "post": {
+        "summary": "Run GPT-5.6 Terra Pro via llm-gpt-5.6-terra-pro API",
+        "description": "OpenAI's higher-compute Terra tier for demanding reasoning workloads",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.6-terra-pro",
+        "x-price": "$0.10",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "100000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "100000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.10",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "100000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate (reasoning models use more)",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.6-sol": {
+      "post": {
+        "summary": "Run GPT-5.6 Sol via llm-gpt-5.6-sol API",
+        "description": "OpenAI's flagship GPT-5.6 tier for complex analysis, coding, and planning",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.6-sol",
+        "x-price": "$0.08",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "80000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "80000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.08",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "80000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate (reasoning models use more)",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gpt-5.6-sol-pro": {
+      "post": {
+        "summary": "Run GPT-5.6 Sol Pro via llm-gpt-5.6-sol-pro API",
+        "description": "OpenAI's maximum-compute GPT-5.6 tier for the hardest agent tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gpt-5.6-sol-pro",
+        "x-price": "$0.20",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.20",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "200000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.20",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "200000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.20",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "200000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate (reasoning models use more)",
+                    "example": 16384,
+                    "default": 16384
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/claude-opus-5": {
+      "post": {
+        "summary": "Run Claude Opus 5 via llm-claude-opus-5 API",
+        "description": "Anthropic's flagship model with 1M context for coding, analysis, and autonomous work",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-claude-opus-5",
+        "x-price": "$0.07",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.07",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "70000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.07",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "70000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.07",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "70000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/claude-opus-5-fast": {
+      "post": {
+        "summary": "Run Claude Opus 5 Fast via llm-claude-opus-5-fast API",
+        "description": "Low-latency Claude Opus 5 delivery for premium interactive workloads",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-claude-opus-5-fast",
+        "x-price": "$0.12",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.12",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "120000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.12",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "120000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.12",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "120000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/claude-sonnet-5": {
+      "post": {
+        "summary": "Run Claude Sonnet 5 via llm-claude-sonnet-5 API",
+        "description": "Anthropic's balanced frontier model with 1M context and strong coding performance",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-claude-sonnet-5",
+        "x-price": "$0.03",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "30000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "30000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "30000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gemini-3.6-flash": {
+      "post": {
+        "summary": "Run Gemini 3.6 Flash via llm-gemini-3.6-flash API",
+        "description": "Google's latest fast multimodal model with a 1M-token context window",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gemini-3.6-flash",
+        "x-price": "$0.02",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "20000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "20000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.02",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "20000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/gemini-3.5-flash-lite": {
+      "post": {
+        "summary": "Run Gemini 3.5 Flash Lite via llm-gemini-3.5-flash-lite API",
+        "description": "Google's low-cost multimodal model for high-volume agent workloads",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-gemini-3.5-flash-lite",
+        "x-price": "$0.006",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "6000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "6000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.006",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "6000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/kimi-k3": {
+      "post": {
+        "summary": "Run Kimi K3 via llm-kimi-k3 API",
+        "description": "MoonshotAI's frontier multimodal model with 1M context for agentic tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-kimi-k3",
+        "x-price": "$0.04",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "40000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "40000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.04",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "40000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/grok-4.5": {
+      "post": {
+        "summary": "Run Grok 4.5 via llm-grok-4.5 API",
+        "description": "xAI's latest multimodal model with 500k context and strong tool use",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-grok-4.5",
+        "x-price": "$0.03",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "30000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "30000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.03",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "30000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/kat-coder-air-v2.5": {
+      "post": {
+        "summary": "Run KAT-Coder-Air V2.5 via llm-kat-coder-air-v2.5 API",
+        "description": "Kwaipilot's efficient coding model for repository and agent workflows",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-kat-coder-air-v2.5",
+        "x-price": "$0.003",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "3000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "3000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "3000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/kat-coder-pro-v2.5": {
+      "post": {
+        "summary": "Run KAT-Coder-Pro V2.5 via llm-kat-coder-pro-v2.5 API",
+        "description": "Kwaipilot's stronger coding model for complex software engineering tasks",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-kat-coder-pro-v2.5",
+        "x-price": "$0.008",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.008",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "8000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.008",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "8000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.008",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "8000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/longcat-2": {
+      "post": {
+        "summary": "Run LongCat 2.0 via llm-longcat-2 API",
+        "description": "Meituan's long-context model for reasoning, coding, and high-volume inference",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-longcat-2",
+        "x-price": "$0.005",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "5000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "5000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.005",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "5000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/inkling": {
+      "post": {
+        "summary": "Run Inkling via llm-inkling API",
+        "description": "Thinking Machines' multimodal model for text, image, and audio understanding",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-inkling",
+        "x-price": "$0.012",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "12000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "12000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "12000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/muse-spark-1.1": {
+      "post": {
+        "summary": "Run Muse Spark 1.1 via llm-muse-spark-1.1 API",
+        "description": "Meta's broad multimodal model with 1M context for media-rich agent workflows",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-muse-spark-1.1",
+        "x-price": "$0.012",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "12000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "12000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "12000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/aion-3.0": {
+      "post": {
+        "summary": "Run Aion 3.0 via llm-aion-3.0 API",
+        "description": "AionLabs' full reasoning model for analysis and structured generation",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-aion-3.0",
+        "x-price": "$0.012",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "12000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "12000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.012",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "12000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/aion-3.0-mini": {
+      "post": {
+        "summary": "Run Aion 3.0 Mini via llm-aion-3.0-mini API",
+        "description": "AionLabs' compact reasoning model for efficient general-purpose inference",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-aion-3.0-mini",
+        "x-price": "$0.004",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.004",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "4000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.004",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "4000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.004",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "4000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/hy3": {
+      "post": {
+        "summary": "Run Tencent HY3 via llm-hy3 API",
+        "description": "Tencent's efficient reasoning model with a 262k-token context window",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-hy3",
+        "x-price": "$0.003",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "3000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "3000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.003",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "3000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/llm/ling-3-flash": {
+      "post": {
+        "summary": "Run Ling 3.0 Flash via llm-ling-3-flash API",
+        "description": "InclusionAI's fast open model for low-cost reasoning and tool use",
+        "tags": [
+          "compute"
+        ],
+        "x-service-id": "llm-ling-3-flash",
+        "x-price": "$0.002",
+        "x-payment-options": [
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:8453",
+            "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            "amount": "2000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USD Coin",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "eip155:4326",
+            "asset": "0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7",
+            "amount": "2000000000000000",
+            "payTo": "0x7dd5Be069f2d2eAd75eC7C3423B116fF043c2629",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "name": "USDm",
+              "version": "2"
+            }
+          },
+          {
+            "scheme": "exact",
+            "price": "$0.002",
+            "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "amount": "2000",
+            "payTo": "Gzehfseq1k9AcHFSoV7qHmDGQx92nLMw78XXdqVWQQWa",
+            "maxTimeoutSeconds": 300,
+            "extra": {
+              "feePayer": "GVJJ7rdGiXr5xaYbRwRbjfaJL7fmwRygFi1H6aGqDveb"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful paid response"
+          },
+          "402": {
+            "description": "Payment required"
+          },
+          "4XX": {
+            "description": "Invalid request or payment"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messages": {
+                    "type": "array",
+                    "description": "Array of message objects with role and content",
+                    "example": [
+                      {
+                        "role": "user",
+                        "content": "Hello"
+                      }
+                    ]
+                  },
+                  "max_tokens": {
+                    "type": "number",
+                    "description": "Maximum tokens to generate",
+                    "example": 1024,
+                    "default": 1024
+                  }
+                },
+                "required": [
+                  "messages"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "x402": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-PAYMENT",
+        "description": "Base64-encoded x402 payment payload."
+      }
+    }
+  }
+}

--- a/providers/x402engine/gateway/openapi.json
+++ b/providers/x402engine/gateway/openapi.json
@@ -138,14 +138,14 @@
                   "width": {
                     "type": "number",
                     "description": "Image width in pixels (256-2048)",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   },
                   "height": {
                     "type": "number",
                     "description": "Image height in pixels (256-2048)",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   },
                   "seed": {
                     "type": "number",
@@ -155,7 +155,8 @@
                 },
                 "required": [
                   "prompt"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -237,14 +238,14 @@
                   "width": {
                     "type": "number",
                     "description": "Image width in pixels (256-2048)",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   },
                   "height": {
                     "type": "number",
                     "description": "Image height in pixels (256-2048)",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   },
                   "seed": {
                     "type": "number",
@@ -254,7 +255,8 @@
                 },
                 "required": [
                   "prompt"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -336,13 +338,14 @@
                   "image_size": {
                     "type": "string",
                     "description": "Output size",
-                    "example": "square",
-                    "default": "square"
+                    "default": "square",
+                    "example": "square"
                   }
                 },
                 "required": [
                   "prompt"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -429,14 +432,14 @@
                   "width": {
                     "type": "number",
                     "description": "Image width in pixels (256-2048)",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   },
                   "height": {
                     "type": "number",
                     "description": "Image height in pixels (256-2048)",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   },
                   "seed": {
                     "type": "number",
@@ -462,7 +465,8 @@
                 "required": [
                   "prompt",
                   "reference_image_url"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -544,14 +548,14 @@
                   "aspect_ratio": {
                     "type": "string",
                     "description": "Output aspect ratio (auto, 21:9, 16:9, 3:2, 4:3, 5:4, 1:1, 4:5, 3:4, 2:3, 9:16)",
-                    "example": "16:9",
-                    "default": "1:1"
+                    "default": "1:1",
+                    "example": "16:9"
                   },
                   "output_format": {
                     "type": "string",
                     "description": "Image format: png, jpeg, or webp",
-                    "example": "png",
-                    "default": "png"
+                    "default": "png",
+                    "example": "png"
                   },
                   "seed": {
                     "type": "number",
@@ -561,7 +565,8 @@
                 },
                 "required": [
                   "prompt"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -643,14 +648,14 @@
                   "duration": {
                     "type": "string",
                     "description": "Fixed video duration",
-                    "example": "5",
-                    "default": "5"
+                    "default": "5",
+                    "example": "5"
                   },
                   "aspect_ratio": {
                     "type": "string",
                     "description": "Output aspect ratio: 16:9, 9:16, or 1:1",
-                    "example": "16:9",
-                    "default": "16:9"
+                    "default": "16:9",
+                    "example": "16:9"
                   },
                   "negative_prompt": {
                     "type": "string",
@@ -660,13 +665,14 @@
                   "generate_audio": {
                     "type": "boolean",
                     "description": "Audio generation is fixed off for deterministic per-call pricing",
-                    "example": false,
-                    "default": false
+                    "default": false,
+                    "example": false
                   }
                 },
                 "required": [
                   "prompt"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -748,14 +754,14 @@
                   "duration": {
                     "type": "string",
                     "description": "Fixed video duration",
-                    "example": "5",
-                    "default": "5"
+                    "default": "5",
+                    "example": "5"
                   },
                   "aspect_ratio": {
                     "type": "string",
                     "description": "Output aspect ratio: 16:9, 9:16, or 1:1",
-                    "example": "16:9",
-                    "default": "16:9"
+                    "default": "16:9",
+                    "example": "16:9"
                   },
                   "negative_prompt": {
                     "type": "string",
@@ -765,13 +771,14 @@
                   "generate_audio": {
                     "type": "boolean",
                     "description": "Audio generation is fixed off for deterministic per-call pricing",
-                    "example": false,
-                    "default": false
+                    "default": false,
+                    "example": false
                   }
                 },
                 "required": [
                   "prompt"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -853,7 +860,8 @@
                 },
                 "required": [
                   "prompt"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -940,8 +948,8 @@
                   "duration": {
                     "type": "string",
                     "description": "Fixed video duration",
-                    "example": "5",
-                    "default": "5"
+                    "default": "5",
+                    "example": "5"
                   },
                   "negative_prompt": {
                     "type": "string",
@@ -951,14 +959,15 @@
                   "generate_audio": {
                     "type": "boolean",
                     "description": "Audio generation is fixed off for deterministic per-call pricing",
-                    "example": false,
-                    "default": false
+                    "default": false,
+                    "example": false
                   }
                 },
                 "required": [
                   "prompt",
                   "image_url"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -1045,20 +1054,20 @@
                   "num_inference_steps": {
                     "type": "number",
                     "description": "Flow-matching inference steps (1-16)",
-                    "example": 4,
-                    "default": 4
+                    "default": 4,
+                    "example": 4
                   },
                   "guidance_scale": {
                     "type": "number",
                     "description": "Classifier-free guidance scale (0-10)",
-                    "example": 3,
-                    "default": 3
+                    "default": 3,
+                    "example": 3
                   },
                   "max_ref_length": {
                     "type": "number",
                     "description": "Max reference audio duration in seconds (1-15)",
-                    "example": 5,
-                    "default": 5
+                    "default": 5,
+                    "example": 5
                   },
                   "seed": {
                     "type": "number",
@@ -1068,7 +1077,8 @@
                 "required": [
                   "text",
                   "audio_url"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -1150,19 +1160,20 @@
                   "language": {
                     "type": "string",
                     "description": "Programming language (python, javascript, bash, r)",
-                    "example": "python",
-                    "default": "python"
+                    "default": "python",
+                    "example": "python"
                   },
                   "timeout": {
                     "type": "number",
                     "description": "Execution timeout in seconds (1-300)",
-                    "example": 60,
-                    "default": 60
+                    "default": 60,
+                    "example": 60
                   }
                 },
                 "required": [
                   "code"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -1230,7 +1241,7 @@
           }
         },
         "requestBody": {
-          "required": false,
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -1252,7 +1263,19 @@
                     "example": "audio/mp3"
                   }
                 },
-                "required": []
+                "anyOf": [
+                  {
+                    "required": [
+                      "audio_url"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "audio_base64"
+                    ]
+                  }
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -1340,8 +1363,8 @@
             "schema": {
               "type": "string",
               "description": "Comma-separated fiat currencies",
-              "example": "usd,eur",
-              "default": "usd"
+              "default": "usd",
+              "example": "usd,eur"
             },
             "example": "usd,eur"
           },
@@ -1439,8 +1462,8 @@
             "schema": {
               "type": "string",
               "description": "Fiat currency for pricing",
-              "example": "usd",
-              "default": "usd"
+              "default": "usd",
+              "example": "usd"
             },
             "example": "usd"
           },
@@ -1464,8 +1487,8 @@
             "schema": {
               "type": "string",
               "description": "Sort order",
-              "example": "market_cap_desc",
-              "default": "market_cap_desc"
+              "default": "market_cap_desc",
+              "example": "market_cap_desc"
             },
             "example": "market_cap_desc"
           },
@@ -1477,8 +1500,8 @@
             "schema": {
               "type": "number",
               "description": "Number of results (1-250)",
-              "example": 100,
-              "default": 100
+              "default": 100,
+              "example": 100
             },
             "example": 100
           },
@@ -1490,8 +1513,8 @@
             "schema": {
               "type": "number",
               "description": "Page number (1-500)",
-              "example": 1,
-              "default": 1
+              "default": 1,
+              "example": 1
             },
             "example": 1
           }
@@ -1579,8 +1602,8 @@
             "schema": {
               "type": "string",
               "description": "Fiat currency",
-              "example": "usd",
-              "default": "usd"
+              "default": "usd",
+              "example": "usd"
             },
             "example": "usd"
           },
@@ -1592,8 +1615,8 @@
             "schema": {
               "type": "string",
               "description": "Days of history (1-365 or \"max\")",
-              "example": "30",
-              "default": "30"
+              "default": "30",
+              "example": "30"
             },
             "example": "30"
           },
@@ -1831,7 +1854,8 @@
                 "required": [
                   "chain",
                   "address"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -1918,13 +1942,14 @@
                   "limit": {
                     "type": "number",
                     "description": "Max results",
-                    "example": 100,
-                    "default": 100
+                    "default": 100,
+                    "example": 100
                   }
                 },
                 "required": [
                   "address"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -2012,7 +2037,8 @@
                 "required": [
                   "chain",
                   "address"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -2094,12 +2120,32 @@
                         "chain": "ethereum",
                         "token_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "chain": {
+                          "type": "string",
+                          "example": "ethereum"
+                        },
+                        "token_address": {
+                          "type": "string",
+                          "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                        }
+                      },
+                      "required": [
+                        "chain",
+                        "token_address"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   }
                 },
                 "required": [
                   "tokens"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -2279,7 +2325,7 @@
                     "example": "data:image/png;base64,..."
                   }
                 },
-                "required": []
+                "additionalProperties": false
               }
             }
           }
@@ -2437,18 +2483,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -2530,18 +2596,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -2623,18 +2709,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate (reasoning models use more)",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -2716,18 +2822,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -2809,18 +2935,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -2902,18 +3048,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -2995,18 +3161,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3088,18 +3274,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3181,18 +3387,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3274,18 +3500,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3367,18 +3613,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3460,18 +3726,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3553,18 +3839,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3646,18 +3952,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3739,18 +4065,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3832,18 +4178,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -3925,18 +4291,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate (reasoning models use more)",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4018,18 +4404,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4111,18 +4517,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4204,18 +4630,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4297,18 +4743,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4390,18 +4856,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4483,18 +4969,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4576,18 +5082,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4669,18 +5195,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4762,18 +5308,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4855,18 +5421,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -4948,18 +5534,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate (reasoning models use more)",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5041,18 +5647,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5134,18 +5760,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5227,18 +5873,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5320,18 +5986,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5413,18 +6099,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5506,18 +6212,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5599,18 +6325,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5692,18 +6438,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5785,18 +6551,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5878,18 +6664,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -5957,7 +6763,7 @@
           }
         },
         "requestBody": {
-          "required": false,
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -5974,10 +6780,28 @@
                     "example": [
                       "hello",
                       "world"
-                    ]
+                    ],
+                    "items": {
+                      "type": "string",
+                      "example": "hello"
+                    },
+                    "minItems": 1,
+                    "maxItems": 100
                   }
                 },
-                "required": []
+                "anyOf": [
+                  {
+                    "required": [
+                      "text"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "texts"
+                    ]
+                  }
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -6222,8 +7046,8 @@
                   "numResults": {
                     "type": "number",
                     "description": "Number of results (1-30)",
-                    "example": 10,
-                    "default": 10
+                    "default": 10,
+                    "example": 10
                   },
                   "includeDomains": {
                     "type": "array",
@@ -6231,7 +7055,11 @@
                     "example": [
                       "arxiv.org",
                       "github.com"
-                    ]
+                    ],
+                    "items": {
+                      "type": "string",
+                      "example": "arxiv.org"
+                    }
                   },
                   "category": {
                     "type": "string",
@@ -6246,7 +7074,8 @@
                 },
                 "required": [
                   "query"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -6325,12 +7154,18 @@
                     "description": "Array of URLs to fetch content from (max 10)",
                     "example": [
                       "https://example.com/article"
-                    ]
+                    ],
+                    "items": {
+                      "type": "string",
+                      "example": "https://example.com/article"
+                    },
+                    "minItems": 1
                   }
                 },
                 "required": [
                   "urls"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -6412,19 +7247,20 @@
                   "voice": {
                     "type": "string",
                     "description": "Voice ID (alloy, echo, fable, onyx, nova, shimmer)",
-                    "example": "alloy",
-                    "default": "alloy"
+                    "default": "alloy",
+                    "example": "alloy"
                   },
                   "model": {
                     "type": "string",
                     "description": "TTS model (tts-1, tts-1-hd)",
-                    "example": "tts-1",
-                    "default": "tts-1"
+                    "default": "tts-1",
+                    "example": "tts-1"
                   }
                 },
                 "required": [
                   "text"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -6511,7 +7347,8 @@
                 },
                 "required": [
                   "text"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -6770,7 +7607,8 @@
                   "network_id",
                   "from",
                   "to"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -7197,18 +8035,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -7290,18 +8148,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -7383,18 +8261,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -7476,18 +8374,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -7569,18 +8487,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -7662,18 +8600,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -7755,18 +8713,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -7848,18 +8826,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -7941,18 +8939,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8034,18 +9052,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8127,18 +9165,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8220,18 +9278,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8313,18 +9391,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate (reasoning models use more)",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8406,18 +9504,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate (reasoning models use more)",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8499,18 +9617,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate (reasoning models use more)",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8592,18 +9730,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate (reasoning models use more)",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8685,18 +9843,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate (reasoning models use more)",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8778,18 +9956,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate (reasoning models use more)",
-                    "example": 16384,
-                    "default": 16384
+                    "default": 16384,
+                    "example": 16384
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8871,18 +10069,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -8964,18 +10182,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9057,18 +10295,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9150,18 +10408,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9243,18 +10521,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9336,18 +10634,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9429,18 +10747,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9522,18 +10860,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9615,18 +10973,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9708,18 +11086,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9801,18 +11199,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9894,18 +11312,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -9987,18 +11425,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -10080,18 +11538,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -10173,18 +11651,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }
@@ -10266,18 +11764,38 @@
                         "role": "user",
                         "content": "Hello"
                       }
-                    ]
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "role": {
+                          "type": "string",
+                          "example": "user"
+                        },
+                        "content": {
+                          "type": "string",
+                          "example": "Hello"
+                        }
+                      },
+                      "required": [
+                        "role",
+                        "content"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1
                   },
                   "max_tokens": {
                     "type": "number",
                     "description": "Maximum tokens to generate",
-                    "example": 1024,
-                    "default": 1024
+                    "default": 1024,
+                    "example": 1024
                   }
                 },
                 "required": [
                   "messages"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }


### PR DESCRIPTION
Adds x402engine to the pay.sh catalog with a co-located OpenAPI snapshot.

- 108 x402-paid APIs, including 72 LLM routes
- USDC payment support on Solana and Base, plus USDm on MegaETH
- Media, audio, web, code, crypto, wallet, travel, and IPFS endpoints
- Canonical service URL: https://x402engine.app

Validation:
- `pay catalog check providers/x402engine/gateway/PAY.md --no-probe`: 112 endpoints walked
- `pay catalog check providers/x402engine/gateway/PAY.md -v`: 108/108 paid gates compatible with Solana