### PR TITLE
docs(purch): clarify buy vs shop, add purchase safety notes

### DIFF
--- a/providers/purch/marketplace/PAY.md
+++ b/providers/purch/marketplace/PAY.md
@@ -14,9 +14,16 @@ digital goods through Purch Vault. All endpoints accept Solana USDC via x402.
 
 Search returns titles, prices, ratings, image URLs, vendors, and product URLs
 mixed across Amazon and Shopify. The `x402/shop` endpoint takes a
-natural-language `message` and returns curated recommendations. Purchases use
-dynamic pricing — the paid amount equals the product total (including shipping
-and tax).
+natural-language `message` and returns curated recommendations — it is
+discovery only and will refuse to execute a purchase even if the message asks
+it to buy something. `POST x402/buy` is the only endpoint that places and
+pays for a physical order; it requires `shippingAddress` and `email`, plus
+either `asin`/`productUrl` (Amazon) or `productUrl`+`variantId` (Shopify).
+Purchases use dynamic pricing — the paid amount equals the product total
+(including shipping and tax) as quoted in the endpoint's own 402 challenge,
+which can differ substantially from the price shown by search (Amazon in
+particular has been observed quoting several times the search-listed price at
+checkout).
 
 Identifiers: Amazon products use `asin` (e.g. `B0CXYZ1234`) or `productUrl`;
 Shopify products use `productUrl` plus `variantId`; vault items use `slug`.
@@ -34,3 +41,16 @@ Solana mainnet.
   `productUrl` plus `variantId` for Shopify, and `slug` for vault items.
 - Do not call purchase endpoints for price discovery. Use search results first,
   then ask the user to pick one item.
+- `x402/shop` never places orders — do not call it expecting a purchase side
+  effect. Route all purchases through `POST x402/buy` (or `x402/vault/buy` for
+  vault items).
+- There is no address book: `x402/buy` requires a full `shippingAddress` on
+  every call. Ask the user for it each time rather than assuming a stored
+  default.
+- Treat the 402 challenge's quoted amount as authoritative, not the search
+  price. If it's meaningfully higher than expected, stop and confirm with the
+  user before approving payment instead of retrying at the higher price.
+- `x402/buy` against Shopify products can intermittently 500 with "Orders from
+  Shopify are temporarily unavailable." No payment is taken when this happens;
+  fall back to an Amazon item or retry later rather than assuming the order or
+  charge went through.


### PR DESCRIPTION
## Summary
- `x402/shop` is discovery-only prose never named the actual purchase endpoint, so an agent following this skill called `x402/shop` expecting it to place an order — it just replied that shopping assistance is out of scope.
- Explicitly names `POST x402/buy` as the only endpoint that places/pays for a physical order, with its required fields.
- Adds spend-aware notes learned from a live run: the 402-quoted checkout price can differ substantially from the search-listed price (observed ~4x on an Amazon item), Shopify checkout can transiently 500 with no charge taken, and there is no address book (always collect `shippingAddress` explicitly).

## Test plan
- [x] `pay catalog check providers/purch/marketplace/PAY.md` — passes (one pre-existing warning unrelated to this change, about an OpenAPI summary string)