### PR TITLE
feat: add Elfa AI provider (Auto condition engine + Iris market intelligence, x402)

### DIFF
--- a/providers/elfa-ai/api/PAY.md
+++ b/providers/elfa-ai/api/PAY.md
@@ -1,0 +1,61 @@
+---
+name: api
+title: "Elfa AI"
+description: "Auto conditional alerts and Iris market intelligence: describe a price or social condition and get a webhook when it fires, over trending assets, mentions, account quality, news and narratives."
+use_case: "Use for Auto conditional alerts: describe a price or social condition on crypto markets and get notified or execute when it fires. Also Iris market intelligence — trending assets, contract-address discovery, mention search, account quality, narratives."
+category: finance
+service_url: https://api.elfa.ai
+version: v2
+openapi:
+  path: openapi.json
+---
+
+Elfa is real-time data infrastructure for financial AI, powered by our
+intelligence stack **Iris**. Iris synthesises signals across social, on-chain and
+off-chain market data, then traces their second and third-order effects, so
+agents act on greater context.
+
+These endpoints serve the same signals our own finance agent runs on,
+pay-per-call over x402 — no API key and no account.
+
+## Auto — the condition engine
+
+Describe what to watch and Elfa fires a webhook when it happens. Register an EQL
+query against price or social conditions; Elfa evaluates it continuously and
+calls you back. Identity is `SHA256(x-elfa-agent-secret)` — invent a secret once
+and reuse it to reach your own queries.
+
+Creating a query is the only paid step. Validating, polling, cancelling, listing
+LLM sessions and the SSE notification stream are all free.
+
+```
+POST /x402/v2/auto/queries/validate   free, returns the exact cost first
+POST /x402/v2/auto/queries            create and activate
+GET  /x402/v2/auto/queries/{id}/stream  live notifications over SSE
+```
+
+## Iris market intelligence
+
+Point-in-time reads of what the market is saying and doing: trending assets and
+contract addresses surfacing on X and Telegram, smart-account stats, keyword
+mention feeds, token news, event summaries and narratives — plus an LLM chat
+endpoint that interprets them.
+
+## Payment
+
+USDC on Solana mainnet, Base, Arbitrum, Polygon and Avalanche. Every rail is
+quoted in the same 402, so pay on whichever you already hold. Solana payments are
+gasless — the facilitator acts as fee payer.
+
+## Spend-aware usage
+
+- Call `POST /x402/v2/auto/queries/validate` (free) before creating a query; it
+  returns the exact cost of the query you are about to register.
+- Poll with `POST /x402/v2/auto/queries/{queryId}` (free) rather than
+  re-creating a query.
+- Start with `/x402/v2/aggregations/trending-tokens` ($0.009) before paying for
+  `/x402/v2/data/event-summary` ($0.045).
+- Cap `pageSize` / `limit` on mention feeds; the defaults return more than most
+  tasks need.
+- `/x402/v2/chat` costs $0.045 at `speed: fast` and $0.162 at `speed: expert` —
+  prefer the structured endpoints when a plain lookup answers the question.

--- a/providers/elfa-ai/api/PAY.md
+++ b/providers/elfa-ai/api/PAY.md
@@ -45,7 +45,10 @@ endpoint that interprets them.
 
 USDC on Solana mainnet, Base, Arbitrum, Polygon and Avalanche. Every rail is
 quoted in the same 402, so pay on whichever you already hold. Solana payments are
-gasless — the facilitator acts as fee payer.
+gasless — the facilitator acts as fee payer — and settle with the `exact` scheme,
+so the price you are quoted is the price you pay.
+
+`GET https://api.elfa.ai/.well-known/x402` lists every payable resource.
 
 ## Spend-aware usage
 
@@ -57,5 +60,5 @@ gasless — the facilitator acts as fee payer.
   `/x402/v2/data/event-summary` ($0.045).
 - Cap `pageSize` / `limit` on mention feeds; the defaults return more than most
   tasks need.
-- `/x402/v2/chat` costs $0.045 at `speed: fast` and $0.162 at `speed: expert` —
-  prefer the structured endpoints when a plain lookup answers the question.
+- `/x402/v2/chat` costs $1 at `speed: fast` and $2 at `speed: expert` — prefer
+  the structured endpoints when a plain lookup answers the question.

--- a/providers/elfa-ai/api/openapi.json
+++ b/providers/elfa-ai/api/openapi.json
@@ -1,0 +1,5155 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elfa AI x402 API",
+    "version": "2.0.0",
+    "description": "Pay-per-call crypto social intelligence and conditional-execution API over x402."
+  },
+  "servers": [
+    {
+      "url": "https://api.elfa.ai"
+    }
+  ],
+  "paths": {
+    "/x402/v2/aggregations/trending-tokens": {
+      "get": {
+        "operationId": "x402-get-trending-tokens-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrendingTokensResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "pageSize": 1,
+                        "page": 1,
+                        "total": 1,
+                        "data": [
+                          {
+                            "change_percent": 1,
+                            "previous_count": 1,
+                            "current_count": 1,
+                            "token": "string"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Retrieve trending tokens based on mention activity and momentum.\n\n**Cost:** 1 credit ($0.009). Requires x402 payment.",
+        "summary": "Fetch trending tokens by mention volume",
+        "tags": [
+          "x402 Aggregations"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Time window for trending analysis (e.g., \"30m\", \"1h\", \"4h\", \"24h\", \"7d\", \"30d\")",
+            "in": "query",
+            "name": "timeWindow",
+            "required": false,
+            "schema": {
+              "default": "7d",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start date (unix timestamp)",
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "End date (unix timestamp)",
+            "in": "query",
+            "name": "to",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Page number for pagination",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Number of items per page",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Minimum number of mentions required",
+            "in": "query",
+            "name": "minMentions",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "format": "double",
+              "type": "number"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.009
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/account/smart-stats": {
+      "get": {
+        "operationId": "x402-get-account-smart-stats-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountSmartStatsResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "averageReach": 1,
+                        "averageEngagement": 1,
+                        "smartFollowingCount": 1
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid parameters"
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Retrieve smart account statistics for a username.\n\n**Cost:** 1 credit ($0.009). Requires x402 payment.",
+        "summary": "Fetch smart-account stats for an X username",
+        "tags": [
+          "x402 Account"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Account username to get stats for",
+            "in": "query",
+            "name": "username",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.009
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/data/top-mentions": {
+      "get": {
+        "operationId": "x402-get-top-mentions-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopMentionsResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": [
+                        {
+                          "tweetId": "string",
+                          "link": "string",
+                          "likeCount": 1,
+                          "repostCount": 1,
+                          "viewCount": 1,
+                          "quoteCount": 1,
+                          "replyCount": 1,
+                          "bookmarkCount": 1,
+                          "mentionedAt": "string",
+                          "type": "repost",
+                          "repostBreakdown": {
+                            "ct": 1,
+                            "smart": 1
+                          }
+                        }
+                      ],
+                      "metadata": {
+                        "pageSize": 1,
+                        "page": 1,
+                        "total": 1
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid parameters"
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Returns the most significant mentions for a given ticker symbol.\n\n**Cost:** 1 credit ($0.009). Requires x402 payment.",
+        "summary": "Fetch top mentions for a ticker symbol",
+        "tags": [
+          "x402 Data"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "The ticker symbol to get mentions for. Use `$` prefix (e.g., `$SOL` or URL-encoded `%24SOL`) for exact cashtag matching only. Without `$`, results include both cashtag mentions and general token references.",
+            "in": "query",
+            "name": "ticker",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time window for mentions (e.g., \"1h\", \"24h\", \"7d\")",
+            "in": "query",
+            "name": "timeWindow",
+            "required": false,
+            "schema": {
+              "default": "1h",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start date (unix timestamp)",
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "End date (unix timestamp)",
+            "in": "query",
+            "name": "to",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Page number for pagination",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Number of items per page",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Set to `false` to exclude reposts (default: included)",
+            "in": "query",
+            "name": "reposts",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.009
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/data/keyword-mentions": {
+      "get": {
+        "operationId": "x402-get-keyword-mentions-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KeywordMentionsResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": [
+                        {
+                          "tweetId": "string",
+                          "link": "string",
+                          "likeCount": 1,
+                          "repostCount": 1,
+                          "viewCount": 1,
+                          "quoteCount": 1,
+                          "replyCount": 1,
+                          "bookmarkCount": 1,
+                          "mentionedAt": "string",
+                          "type": "repost",
+                          "repostBreakdown": {
+                            "ct": 1,
+                            "smart": 1
+                          }
+                        }
+                      ],
+                      "metadata": {
+                        "total": 1
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid parameters"
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Search mentions by keywords or account with cursor pagination.\n\n**Cost:** 1 credit ($0.009). Requires x402 payment.",
+        "summary": "Search mentions by keyword or account",
+        "tags": [
+          "x402 Data"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Up to 5 keywords to search for, separated by commas (optional if accountName provided)",
+            "in": "query",
+            "name": "keywords",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Account username to filter by (optional if keywords provided)",
+            "in": "query",
+            "name": "accountName",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time window for mentions (e.g., \"1h\", \"24h\", \"7d\")",
+            "in": "query",
+            "name": "timeWindow",
+            "required": false,
+            "schema": {
+              "default": "7d",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start date (unix timestamp)",
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "End date (unix timestamp)",
+            "in": "query",
+            "name": "to",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Number of results to return (max 30)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Type of search (and, or)",
+            "in": "query",
+            "name": "searchType",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Cursor for pagination (millisecond timestamp from a previous response's `metadata.cursor`)",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Set to `false` to exclude reposts (default: included)",
+            "in": "query",
+            "name": "reposts",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.009
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/data/event-summary": {
+      "get": {
+        "operationId": "x402-get-event-summary-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventSummaryResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": [
+                        {
+                          "tweetIds": [
+                            "string"
+                          ],
+                          "sourceLinks": [
+                            "string"
+                          ],
+                          "summary": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid parameters"
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Get event summary generated from keyword mention windows.\n\n**Cost:** 5 credits ($0.045). Requires x402 payment.",
+        "summary": "Summarize events from keyword mentions",
+        "tags": [
+          "x402 Data"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Keywords to search for, separated by commas",
+            "in": "query",
+            "name": "keywords",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start date (unix timestamp)",
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "End date (unix timestamp)",
+            "in": "query",
+            "name": "to",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Time window for mentions (e.g., \"30m\", \"1h\", \"4h\", \"24h\", \"7d\", \"30d\")",
+            "in": "query",
+            "name": "timeWindow",
+            "required": false,
+            "schema": {
+              "default": "24h",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Type of search (and, or)",
+            "in": "query",
+            "name": "searchType",
+            "required": false,
+            "schema": {
+              "default": "and",
+              "type": "string",
+              "enum": [
+                "and",
+                "or"
+              ]
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.045
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/data/trending-narratives": {
+      "get": {
+        "operationId": "x402-get-trending-narratives-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrendingNarrativesResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "metadata": {
+                          "error": "string",
+                          "total_tweets": 1,
+                          "total_narratives": 1
+                        },
+                        "trending_narratives": [
+                          {
+                            "tweet_ids": [
+                              "string"
+                            ],
+                            "source_links": [
+                              "string"
+                            ],
+                            "narrative": "string"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Analyze narrative trends from recent market discussions.\n\n**Cost:** 5 credits ($0.045). Requires x402 payment.",
+        "summary": "List trending narratives with sample posts",
+        "tags": [
+          "x402 Data"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Time frame for analysis (day, week)",
+            "in": "query",
+            "name": "timeFrame",
+            "required": false,
+            "schema": {
+              "default": "day",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of narratives to return (1-20)",
+            "in": "query",
+            "name": "maxNarratives",
+            "required": false,
+            "schema": {
+              "default": 7,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Maximum number of tweets per narrative (1-20)",
+            "in": "query",
+            "name": "maxTweetsPerNarrative",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "format": "double",
+              "type": "number"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.045
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/data/token-news": {
+      "get": {
+        "operationId": "x402-get-token-news-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenNewsResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": [
+                        {
+                          "tweetId": "string",
+                          "link": "string",
+                          "likeCount": 1,
+                          "repostCount": 1,
+                          "viewCount": 1,
+                          "quoteCount": 1,
+                          "replyCount": 1,
+                          "bookmarkCount": 1,
+                          "mentionedAt": "string",
+                          "type": "repost",
+                          "repostBreakdown": {
+                            "ct": 1,
+                            "smart": 1
+                          }
+                        }
+                      ],
+                      "metadata": {
+                        "pageSize": 1,
+                        "page": 1,
+                        "total": 1
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid parameters"
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Get token-related news mention feed.\n\n**Cost:** 1 credit ($0.009). Requires x402 payment.",
+        "summary": "Fetch the token news mentions feed",
+        "tags": [
+          "x402 Data"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Time window for mentions (e.g., \"30m\", \"1h\", \"4h\", \"24h\", \"7d\", \"30d\")",
+            "in": "query",
+            "name": "timeWindow",
+            "required": false,
+            "schema": {
+              "default": "7d",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start date (unix timestamp)",
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "End date (unix timestamp)",
+            "in": "query",
+            "name": "to",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Page number for pagination",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Number of items per page",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "CoinGecko Coin IDs to filter by, comma-separated",
+            "in": "query",
+            "name": "coinIds",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Set to `false` to exclude reposts (default: included)",
+            "in": "query",
+            "name": "reposts",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.009
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/aggregations/trending-cas/twitter": {
+      "get": {
+        "operationId": "x402-get-trending-cas-twitter-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrendingCAsResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "pageSize": 1,
+                        "page": 1,
+                        "total": 1,
+                        "data": [
+                          {
+                            "contractAddress": "string",
+                            "chain": "ethereum",
+                            "mentionCount": 1
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Retrieve trending contract addresses on Twitter.\n\n**Cost:** 1 credit ($0.009). Requires x402 payment.",
+        "summary": "List trending contract addresses on X",
+        "tags": [
+          "x402 Aggregations"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Time window for trending analysis (e.g., \"30m\", \"1h\", \"4h\", \"24h\", \"7d\", \"30d\")",
+            "in": "query",
+            "name": "timeWindow",
+            "required": false,
+            "schema": {
+              "default": "24h",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start date (unix timestamp)",
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "End date (unix timestamp)",
+            "in": "query",
+            "name": "to",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Page number for pagination",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Number of items per page",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Minimum number of mentions required",
+            "in": "query",
+            "name": "minMentions",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "format": "double",
+              "type": "number"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.009
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/aggregations/trending-cas/telegram": {
+      "get": {
+        "operationId": "x402-get-trending-cas-telegram-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrendingCAsResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "pageSize": 1,
+                        "page": 1,
+                        "total": 1,
+                        "data": [
+                          {
+                            "contractAddress": "string",
+                            "chain": "ethereum",
+                            "mentionCount": 1
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Retrieve trending contract addresses on Telegram.\n\n**Cost:** 1 credit ($0.009). Requires x402 payment.",
+        "summary": "List trending contract addresses on Telegram",
+        "tags": [
+          "x402 Aggregations"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Time window for trending analysis (e.g., \"30m\", \"1h\", \"4h\", \"24h\", \"7d\", \"30d\")",
+            "in": "query",
+            "name": "timeWindow",
+            "required": false,
+            "schema": {
+              "default": "24h",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start date (unix timestamp)",
+            "in": "query",
+            "name": "from",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "End date (unix timestamp)",
+            "in": "query",
+            "name": "to",
+            "required": false,
+            "schema": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Page number for pagination",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Number of items per page",
+            "in": "query",
+            "name": "pageSize",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "format": "double",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Minimum number of mentions required",
+            "in": "query",
+            "name": "minMentions",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "format": "double",
+              "type": "number"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "dimensions": [
+            {
+              "direction": "usage",
+              "unit": "requests",
+              "scale": 1,
+              "tiers": [
+                {
+                  "price_usd": 0.009
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/chat": {
+      "post": {
+        "operationId": "x402-chat-v2",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatResponseV2"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "creditsConsumed": 1,
+                        "sessionId": "string",
+                        "message": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Send a message to Elfa AI and receive a complete response.\n\n`message` is required for `analysisType: \"chat\"` and ignored for other\nanalysis types. `adaptive` speed is not available on x402.\n\n**Cost:** speed based (`fast` 5 credits/$0.045, `expert` 18 credits/$0.162).\nRequires x402 payment.",
+        "summary": "Generate an AI answer about crypto markets",
+        "tags": [
+          "x402 Chat"
+        ],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "description": "Chat request: `message`, `analysisType`, and `speed`",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/X402ChatRequestBody",
+                "description": "Chat request: `message`, `analysisType`, and `speed`"
+              },
+              "examples": {
+                "default": {
+                  "summary": "Example request",
+                  "value": {
+                    "analysisType": "summary",
+                    "speed": "fast"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "variants": [
+            {
+              "param": "speed",
+              "value": "fast",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0.045
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "param": "speed",
+              "value": "expert",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0.162
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/auto/chat": {
+      "post": {
+        "operationId": "x402-auto-chat",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoChatResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "success": true,
+                      "data": {
+                        "creditsConsumed": 1,
+                        "sessionId": "string",
+                        "message": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          }
+        },
+        "description": "Ask the AI to help you build an EQL query. It can research live market data, suggest strategies, and return ready-to-use EQL JSON.\n\nThe response message contains the AI's reply in Markdown. When it generates EQL,\nit will be in a JSON code block that you can extract, validate, and submit.\n\nUse `sessionId` in follow-up requests to maintain conversation context.\n\n**Cost:** speed based (`fast` 5 credits/$0.045, `expert` 18 credits/$0.162).\nRequires x402 payment.",
+        "summary": "Generate an Auto plan from a prompt",
+        "tags": [
+          "x402 Auto"
+        ],
+        "security": [],
+        "parameters": [],
+        "requestBody": {
+          "description": "Chat request: `query_package`, `speed`, and optional `sessionId`",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutoChatRequestBody",
+                "description": "Chat request: `query_package`, `speed`, and optional `sessionId`"
+              },
+              "examples": {
+                "default": {
+                  "summary": "Example request",
+                  "value": {
+                    "message": "Build an Auto query for ETH downside alert under 2500.",
+                    "speed": "fast"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "variants": [
+            {
+              "param": "speed",
+              "value": "fast",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0.045
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "param": "speed",
+              "value": "expert",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0.162
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/auto/queries/validate": {
+      "post": {
+        "operationId": "x402-auto-validate-query",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidateQueryResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "valid": true,
+                      "errors": [
+                        "string"
+                      ],
+                      "warnings": [
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Validate EQL syntax and get a cost estimate without creating a query.\nReturns a simulation-based cost estimate when the query is valid.\nRequires `x-elfa-agent-secret` header.\n\n**Cost:** Free",
+        "summary": "Validate an EQL query without creating it",
+        "tags": [
+          "x402 Auto"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Any string you choose. Identity is `SHA256(secret)`, so reuse the same value across calls to reach your own queries.",
+            "in": "header",
+            "name": "x-elfa-agent-secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Request body carrying the EQL `query` to validate",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidateQueryRequestBody",
+                "description": "Request body carrying the EQL `query` to validate"
+              },
+              "examples": {
+                "default": {
+                  "summary": "Example request",
+                  "value": {
+                    "query": {
+                      "conditions": {
+                        "AND": [
+                          {
+                            "source": "price",
+                            "method": "current",
+                            "args": {
+                              "symbol": "ETH"
+                            },
+                            "operator": "<",
+                            "value": 2500
+                          }
+                        ]
+                      },
+                      "actions": [
+                        {
+                          "stepId": "step_1",
+                          "type": "webhook",
+                          "params": {
+                            "url": "https://your-runner.example/auto/events"
+                          }
+                        }
+                      ],
+                      "expiresIn": "24h"
+                    },
+                    "title": "ETH downside guardrail",
+                    "description": "Alert if ETH breaks below 2500 so risk can be reviewed quickly."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-pay-metering": {
+          "variants": [
+            {
+              "param": "free",
+              "value": "true",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/auto/queries": {
+      "post": {
+        "operationId": "x402-auto-create-query",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateQueryResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "queryId": "string",
+                      "status": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Query created and activated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateQueryResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "queryId": "string",
+                      "status": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required (x402)"
+          },
+          "422": {
+            "description": "EQL validation failed"
+          }
+        },
+        "description": "Create and activate a conditional query that monitors market data and triggers actions when conditions are met.\n\n**Allowed action types:** `webhook`, `notify`, `telegram_bot`, `llm`.\nTrade execution is not available via x402.\n\n**Cost:** Dynamic. Base fee is 5 credits ($0.045) plus simulated LLM calls:\nfast = +5 credits (+$0.045) per call, expert = +18 credits (+$0.162) per call.\nUse the validate endpoint to preview costs.\nRequires `x-elfa-agent-secret` header.\nRequires x402 payment.",
+        "summary": "Create conditional query",
+        "tags": [
+          "x402 Auto"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "Any string you choose. Identity is `SHA256(secret)`, so reuse the same value across calls to reach your own queries.",
+            "in": "header",
+            "name": "x-elfa-agent-secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Request body carrying the EQL `query` and an optional `title`",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateQueryRequestBody",
+                "description": "Request body carrying the EQL `query` and an optional `title`"
+              },
+              "examples": {
+                "default": {
+                  "summary": "Example request",
+                  "value": {
+                    "query": {
+                      "conditions": {
+                        "AND": [
+                          {
+                            "source": "price",
+                            "method": "current",
+                            "args": {
+                              "symbol": "SOL"
+                            },
+                            "operator": ">",
+                            "value": 220
+                          }
+                        ]
+                      },
+                      "actions": [
+                        {
+                          "stepId": "step_1",
+                          "type": "telegram_bot",
+                          "params": {
+                            "botToken": "<telegram-bot-token>",
+                            "chatId": "<telegram-chat-id>"
+                          }
+                        }
+                      ],
+                      "expiresIn": "24h"
+                    },
+                    "title": "SOL breakout alert",
+                    "description": "Send a Telegram alert if SOL trades above 220."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-pay-metering": {
+          "schemes": [
+            "x402-exact"
+          ],
+          "variants": [
+            {
+              "param": "speed",
+              "value": "fast",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0.09
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "param": "speed",
+              "value": "expert",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0.207
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/auto/queries/{queryId}": {
+      "post": {
+        "operationId": "x402-auto-poll-query",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PollQueryResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "queryId": "string",
+                      "status": "string",
+                      "latestEvaluation": {
+                        "evaluatedAt": "string",
+                        "conditionStates": [
+                          {
+                            "index": 1,
+                            "source": "string",
+                            "method": "string"
+                          }
+                        ],
+                        "wouldTriggerNow": true,
+                        "matchingConditions": 1,
+                        "totalConditions": 1
+                      },
+                      "executions": [
+                        {
+                          "id": "string",
+                          "queryId": "string",
+                          "type": "string",
+                          "status": "string",
+                          "createdAt": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Query not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Check query status and execution results.\nRequires `x-elfa-agent-secret` header.\n\n`latestEvaluation` is the latest current-state snapshot, including\n`conditionStates[]`. Execution records include Auto Trigger Context\n(`triggerTime`, `conditionsMet`, `trigger`) when the query has fired.\n\n**Cost:** Free",
+        "summary": "Poll query status and execution results",
+        "tags": [
+          "x402 Auto"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "The unique query identifier",
+            "in": "path",
+            "name": "queryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Any string you choose. Identity is `SHA256(secret)`, so reuse the same value across calls to reach your own queries.",
+            "in": "header",
+            "name": "x-elfa-agent-secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "variants": [
+            {
+              "param": "free",
+              "value": "true",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/auto/queries/{queryId}/cancel": {
+      "post": {
+        "operationId": "x402-auto-cancel-query",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelQueryResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "id": "string",
+                      "status": "string",
+                      "cancelledAt": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Query not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Query not in a cancellable state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Cancel an active query.\nRequires `x-elfa-agent-secret` header.\n\n**Cost:** Free",
+        "summary": "Cancel an active conditional query",
+        "tags": [
+          "x402 Auto"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "The unique query identifier",
+            "in": "path",
+            "name": "queryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Any string you choose. Identity is `SHA256(secret)`, so reuse the same value across calls to reach your own queries.",
+            "in": "header",
+            "name": "x-elfa-agent-secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "variants": [
+            {
+              "param": "free",
+              "value": "true",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/auto/queries/{queryId}/sessions": {
+      "post": {
+        "operationId": "x402-auto-list-sessions",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSessionsResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "queryId": "string",
+                      "sessions": [
+                        {
+                          "sessionId": "string",
+                          "status": "string",
+                          "executedAt": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List LLM output sessions for a query.\nOnly relevant for queries with `actions[0].type: \"llm\"`.\nRequires `x-elfa-agent-secret` header.\n\n**Cost:** Free",
+        "summary": "List LLM analysis sessions for a query",
+        "tags": [
+          "x402 Auto"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "The unique query identifier",
+            "in": "path",
+            "name": "queryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Any string you choose. Identity is `SHA256(secret)`, so reuse the same value across calls to reach your own queries.",
+            "in": "header",
+            "name": "x-elfa-agent-secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "variants": [
+            {
+              "param": "free",
+              "value": "true",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/auto/queries/{queryId}/sessions/{sessionId}": {
+      "post": {
+        "operationId": "x402-auto-get-session",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSessionResponse"
+                },
+                "examples": {
+                  "success": {
+                    "summary": "Example successful response",
+                    "value": {
+                      "sessionId": "string",
+                      "queryId": "string",
+                      "title": "string",
+                      "analysisType": "string",
+                      "createdAt": "string",
+                      "messages": [
+                        {
+                          "query": "string",
+                          "response": "string",
+                          "status": "string",
+                          "analysisType": "string",
+                          "timestamp": "string",
+                          "trades": [
+                            {}
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get full LLM analysis output for a specific session, including conversation messages and any trade signals.\nRequires `x-elfa-agent-secret` header.\n\n**Cost:** Free",
+        "summary": "Get full LLM output for one session",
+        "tags": [
+          "x402 Auto"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "The unique query identifier",
+            "in": "path",
+            "name": "queryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The session identifier from the execution",
+            "in": "path",
+            "name": "sessionId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Any string you choose. Identity is `SHA256(secret)`, so reuse the same value across calls to reach your own queries.",
+            "in": "header",
+            "name": "x-elfa-agent-secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "variants": [
+            {
+              "param": "free",
+              "value": "true",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "/x402/v2/auto/queries/{queryId}/stream": {
+      "get": {
+        "operationId": "x402-auto-stream-notifications",
+        "responses": {
+          "200": {
+            "description": "SSE stream established (text/event-stream)"
+          },
+          "204": {
+            "description": "No content"
+          },
+          "400": {
+            "description": "Missing secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Query not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Query stream closed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Stream query notifications via Server-Sent Events (SSE).\nRequires `x-elfa-agent-secret` header.\n\n**Cost:** Free",
+        "summary": "Monitor query notifications over SSE",
+        "tags": [
+          "x402 Auto"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "description": "The unique query identifier",
+            "in": "path",
+            "name": "queryId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Any string you choose. Identity is `SHA256(secret)`, so reuse the same value across calls to reach your own queries.",
+            "in": "header",
+            "name": "x-elfa-agent-secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-pay-metering": {
+          "variants": [
+            {
+              "param": "free",
+              "value": "true",
+              "dimensions": [
+                {
+                  "direction": "usage",
+                  "unit": "requests",
+                  "scale": 1,
+                  "tiers": [
+                    {
+                      "price_usd": 0
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "examples": {},
+    "headers": {},
+    "parameters": {},
+    "requestBodies": {},
+    "responses": {},
+    "schemas": {
+      "PingResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "nullable": false
+          },
+          "data": {
+            "properties": {
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyStatusDataV2": {
+        "properties": {
+          "id": {
+            "type": "number",
+            "format": "double"
+          },
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "revoked",
+              "expired",
+              "payment_required"
+            ]
+          },
+          "dailyRequestLimit": {
+            "type": "number",
+            "format": "double"
+          },
+          "monthlyRequestLimit": {
+            "type": "number",
+            "format": "double"
+          },
+          "expiresAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "format": "date-time"
+              }
+            ]
+          },
+          "createdAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "format": "date-time"
+              }
+            ]
+          },
+          "updatedAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "format": "date-time"
+              }
+            ]
+          },
+          "requestsPerMinute": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "project": {
+            "type": "string",
+            "nullable": true
+          },
+          "allowOverage": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "maxOverage": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "tier": {
+            "type": "string"
+          },
+          "depositCredits": {
+            "type": "number",
+            "format": "double"
+          },
+          "billingMode": {
+            "type": "string",
+            "enum": [
+              "deposit",
+              "arrears"
+            ]
+          },
+          "usage": {
+            "properties": {
+              "monthly": {
+                "type": "number",
+                "format": "double"
+              },
+              "daily": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "monthly",
+              "daily"
+            ],
+            "type": "object"
+          },
+          "limits": {
+            "properties": {
+              "monthly": {
+                "type": "number",
+                "format": "double"
+              },
+              "daily": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "monthly",
+              "daily"
+            ],
+            "type": "object"
+          },
+          "isExpired": {
+            "type": "boolean"
+          },
+          "remainingRequests": {
+            "properties": {
+              "monthly": {
+                "type": "number",
+                "format": "double"
+              },
+              "daily": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "monthly",
+              "daily"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "key",
+          "name",
+          "status",
+          "dailyRequestLimit",
+          "monthlyRequestLimit",
+          "expiresAt",
+          "createdAt",
+          "updatedAt",
+          "requestsPerMinute",
+          "email",
+          "project",
+          "allowOverage",
+          "maxOverage",
+          "tier",
+          "depositCredits",
+          "billingMode",
+          "usage",
+          "limits",
+          "isExpired",
+          "remainingRequests"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyStatusResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "$ref": "#/components/schemas/ApiKeyStatusDataV2"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TrendingTokensResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "properties": {
+              "pageSize": {
+                "type": "number",
+                "format": "double"
+              },
+              "page": {
+                "type": "number",
+                "format": "double"
+              },
+              "total": {
+                "type": "number",
+                "format": "double"
+              },
+              "data": {
+                "items": {
+                  "properties": {
+                    "change_percent": {
+                      "type": "number",
+                      "format": "double"
+                    },
+                    "previous_count": {
+                      "type": "number",
+                      "format": "double"
+                    },
+                    "current_count": {
+                      "type": "number",
+                      "format": "double"
+                    },
+                    "token": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "change_percent",
+                    "previous_count",
+                    "current_count",
+                    "token"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "pageSize",
+              "page",
+              "total",
+              "data"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AccountSmartStatsResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "properties": {
+              "followerCount": {
+                "type": "number",
+                "format": "double"
+              },
+              "smartFollowerCount": {
+                "type": "number",
+                "format": "double"
+              },
+              "averageReach": {
+                "type": "number",
+                "format": "double"
+              },
+              "averageEngagement": {
+                "type": "number",
+                "format": "double"
+              },
+              "smartFollowingCount": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "averageReach",
+              "averageEngagement",
+              "smartFollowingCount"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "MentionV2": {
+        "description": "A single sanitized mention returned by V2 data endpoints.\n\nV2 never returns raw tweet text or content — use `link` to fetch the original\ntweet if needed. `mentionedAt` is an ISO 8601 string.",
+        "properties": {
+          "tweetId": {
+            "type": "string",
+            "description": "Tweet ID (string to preserve precision across 64-bit IDs)."
+          },
+          "link": {
+            "type": "string",
+            "description": "URL to the source tweet."
+          },
+          "likeCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "repostCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "viewCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "quoteCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "replyCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "bookmarkCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "mentionedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp (e.g. \"2026-04-18T15:07:49+00:00\"). Not a unix timestamp."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "repost",
+              "post",
+              "quote",
+              "reply",
+              "note",
+              "article"
+            ]
+          },
+          "repostBreakdown": {
+            "properties": {
+              "ct": {
+                "type": "number",
+                "format": "double"
+              },
+              "smart": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "ct",
+              "smart"
+            ],
+            "type": "object",
+            "description": "Reposts broken down by audience: `smart` = smart accounts, `ct` = crypto-Twitter accounts."
+          }
+        },
+        "required": [
+          "tweetId",
+          "link",
+          "likeCount",
+          "repostCount",
+          "viewCount",
+          "quoteCount",
+          "replyCount",
+          "bookmarkCount",
+          "mentionedAt",
+          "type",
+          "repostBreakdown"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TopMentionsResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/MentionV2"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "properties": {
+              "pageSize": {
+                "type": "number",
+                "format": "double"
+              },
+              "page": {
+                "type": "number",
+                "format": "double"
+              },
+              "total": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "pageSize",
+              "page",
+              "total"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data",
+          "metadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "KeywordMentionV2": {
+        "description": "Mention returned by `/v2/data/keyword-mentions`. Includes minimal account\ninfo; no follower counts, display name, bio, or account ID are returned.",
+        "properties": {
+          "tweetId": {
+            "type": "string",
+            "description": "Tweet ID (string to preserve precision across 64-bit IDs)."
+          },
+          "link": {
+            "type": "string",
+            "description": "URL to the source tweet."
+          },
+          "likeCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "repostCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "viewCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "quoteCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "replyCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "bookmarkCount": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "mentionedAt": {
+            "type": "string",
+            "description": "ISO 8601 timestamp (e.g. \"2026-04-18T15:07:49+00:00\"). Not a unix timestamp."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "repost",
+              "post",
+              "quote",
+              "reply",
+              "note",
+              "article"
+            ]
+          },
+          "repostBreakdown": {
+            "properties": {
+              "ct": {
+                "type": "number",
+                "format": "double"
+              },
+              "smart": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "ct",
+              "smart"
+            ],
+            "type": "object",
+            "description": "Reposts broken down by audience: `smart` = smart accounts, `ct` = crypto-Twitter accounts."
+          },
+          "account": {
+            "properties": {
+              "isVerified": {
+                "type": "boolean"
+              },
+              "username": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "isVerified",
+              "username"
+            ],
+            "type": "object",
+            "description": "Minimal account info for the author. Only `username` and `isVerified` are\nreturned — no id, display name, follower count, or bio. May be omitted if\nthe underlying record is missing an account name."
+          }
+        },
+        "required": [
+          "tweetId",
+          "link",
+          "likeCount",
+          "repostCount",
+          "viewCount",
+          "quoteCount",
+          "replyCount",
+          "bookmarkCount",
+          "mentionedAt",
+          "type",
+          "repostBreakdown"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "KeywordMentionsResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/KeywordMentionV2"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "properties": {
+              "cursor": {
+                "type": "number",
+                "format": "double"
+              },
+              "total": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "total"
+            ],
+            "type": "object",
+            "description": "Pagination metadata. `cursor` is a millisecond timestamp — pass it back as\nthe `cursor` query param to fetch the next page. Omitted once `data` is\nempty, which is the signal to stop paging. `total` is the complete\nmatching result set, not the remainder after the cursor, and may be\ncapped at 10000 for performance."
+          }
+        },
+        "required": [
+          "success",
+          "data",
+          "metadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "EventSummaryResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "items": {
+              "properties": {
+                "tweetIds": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "sourceLinks": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "summary": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "tweetIds",
+                "sourceLinks",
+                "summary"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "properties": {
+              "summaries": {
+                "type": "number",
+                "format": "double"
+              },
+              "total_summarized": {
+                "type": "number",
+                "format": "double"
+              },
+              "total": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "summaries",
+              "total_summarized",
+              "total"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TrendingNarrativesResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "properties": {
+              "metadata": {
+                "properties": {
+                  "error": {
+                    "type": "string"
+                  },
+                  "total_tweets": {
+                    "type": "number",
+                    "format": "double"
+                  },
+                  "total_narratives": {
+                    "type": "number",
+                    "format": "double"
+                  }
+                },
+                "type": "object"
+              },
+              "trending_narratives": {
+                "items": {
+                  "properties": {
+                    "tweet_ids": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "source_links": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "narrative": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "tweet_ids",
+                    "source_links",
+                    "narrative"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "metadata",
+              "trending_narratives"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TokenNewsResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/MentionV2"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "properties": {
+              "pageSize": {
+                "type": "number",
+                "format": "double"
+              },
+              "page": {
+                "type": "number",
+                "format": "double"
+              },
+              "total": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "pageSize",
+              "page",
+              "total"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data",
+          "metadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TrendingContractAddressV2": {
+        "properties": {
+          "contractAddress": {
+            "type": "string"
+          },
+          "chain": {
+            "type": "string",
+            "enum": [
+              "ethereum",
+              "solana"
+            ]
+          },
+          "mentionCount": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "required": [
+          "contractAddress",
+          "chain",
+          "mentionCount"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TrendingCAsResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "properties": {
+              "pageSize": {
+                "type": "number",
+                "format": "double"
+              },
+              "page": {
+                "type": "number",
+                "format": "double"
+              },
+              "total": {
+                "type": "number",
+                "format": "double"
+              },
+              "data": {
+                "items": {
+                  "$ref": "#/components/schemas/TrendingContractAddressV2"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "pageSize",
+              "page",
+              "total",
+              "data"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ChatResponseV2": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "properties": {
+              "creditsConsumed": {
+                "type": "number",
+                "format": "double"
+              },
+              "sessionId": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "creditsConsumed",
+              "sessionId",
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ChatAssetMetadataV2": {
+        "properties": {
+          "symbol": {
+            "type": "string",
+            "description": "Token ticker symbol (e.g. \"BTC\", \"$ETH\"). Required for tokenIntro / tokenAnalysis when contractAddress is not provided."
+          },
+          "chain": {
+            "type": "string",
+            "description": "Blockchain name (e.g. \"ethereum\", \"solana\"). Use together with contractAddress as an alternative to symbol."
+          },
+          "contractAddress": {
+            "type": "string",
+            "description": "Token contract address. Use together with chain as an alternative to symbol."
+          },
+          "username": {
+            "type": "string",
+            "description": "Twitter/X username. Required for accountAnalysis."
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ChatRequestBodyV2": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "The user message. Required when analysisType is \"chat\"; ignored for all other analysis types."
+          },
+          "sessionId": {
+            "type": "string",
+            "description": "Omit to start a new conversation. Pass the sessionId from a previous response to continue an existing conversation."
+          },
+          "analysisType": {
+            "type": "string",
+            "enum": [
+              "chat",
+              "macro",
+              "summary",
+              "tokenIntro",
+              "tokenAnalysis",
+              "accountAnalysis"
+            ],
+            "description": "The type of analysis to perform. Defaults to \"chat\".\n- `chat` — conversational AI. Requires `message`.\n- `macro` — macro market overview.\n- `summary` — quick market summary.\n- `tokenIntro` — token introduction. Requires `assetMetadata`.\n- `tokenAnalysis` — in-depth token analysis. Requires `assetMetadata`.\n- `accountAnalysis` — Twitter/X account analysis. Requires `assetMetadata.username`.",
+            "default": "chat"
+          },
+          "speed": {
+            "type": "string",
+            "enum": [
+              "fast",
+              "expert",
+              "adaptive"
+            ],
+            "description": "Response quality mode.",
+            "default": "expert"
+          },
+          "assetMetadata": {
+            "$ref": "#/components/schemas/ChatAssetMetadataV2",
+            "description": "Required for tokenIntro, tokenAnalysis, and accountAnalysis. See endpoint description for required fields per analysis type."
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TokenInsight": {
+        "properties": {
+          "cgCoinId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "sentiment": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number",
+            "format": "double"
+          },
+          "link": {
+            "type": "string"
+          },
+          "supportingTweets": {
+            "items": {
+              "properties": {
+                "author": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "username": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "username"
+                  ],
+                  "type": "object"
+                },
+                "timestamp": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "author",
+                "timestamp",
+                "url",
+                "content"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "cgCoinId",
+          "title",
+          "description",
+          "sentiment",
+          "timestamp",
+          "link",
+          "supportingTweets"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "TokenInsightsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/TokenInsight"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "properties": {
+              "offset": {
+                "type": "number",
+                "format": "double"
+              },
+              "limit": {
+                "type": "number",
+                "format": "double"
+              },
+              "to": {
+                "type": "number",
+                "format": "double"
+              },
+              "from": {
+                "type": "number",
+                "format": "double"
+              },
+              "total": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "offset",
+              "limit",
+              "to",
+              "from",
+              "total"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "data",
+          "metadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Insight": {
+        "properties": {
+          "chain": {
+            "type": "string"
+          },
+          "contractAddress": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "sentiment": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number",
+            "format": "double"
+          },
+          "link": {
+            "type": "string"
+          },
+          "supportingTweets": {
+            "items": {
+              "properties": {
+                "author": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "username": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "username"
+                  ],
+                  "type": "object"
+                },
+                "timestamp": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "author",
+                "timestamp",
+                "url",
+                "content"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "chain",
+          "contractAddress",
+          "title",
+          "description",
+          "sentiment",
+          "timestamp",
+          "link",
+          "supportingTweets"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "InsightsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Insight"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "properties": {
+              "offset": {
+                "type": "number",
+                "format": "double"
+              },
+              "limit": {
+                "type": "number",
+                "format": "double"
+              },
+              "to": {
+                "type": "number",
+                "format": "double"
+              },
+              "from": {
+                "type": "number",
+                "format": "double"
+              },
+              "total": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "offset",
+              "limit",
+              "to",
+              "from",
+              "total"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "data",
+          "metadata"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyAutoChatResponse": {
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Session ID for continuing this conversation"
+          },
+          "response": {
+            "type": "string",
+            "description": "AI response in plain text/markdown"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true,
+            "description": "Optional generated title"
+          },
+          "reasoning": {
+            "type": "string",
+            "nullable": true,
+            "description": "Optional reasoning trace"
+          },
+          "planIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Related plan IDs"
+          }
+        },
+        "required": [
+          "sessionId",
+          "response",
+          "title",
+          "reasoning",
+          "planIds"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Record_string.unknown_": {
+        "properties": {},
+        "additionalProperties": {},
+        "type": "object",
+        "description": "Construct a type with a set of properties K of type T"
+      },
+      "JsonObject": {
+        "$ref": "#/components/schemas/Record_string.unknown_"
+      },
+      "ApiKeyAutoValidationErrorDetail": {
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "Request field path, e.g. `body.credentials.secret`"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable validation message"
+          }
+        },
+        "required": [
+          "field",
+          "message"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyAutoErrorDetails": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/JsonObject"
+          },
+          {
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyAutoValidationErrorDetail"
+            },
+            "type": "array"
+          }
+        ]
+      },
+      "ApiKeyAutoErrorResponse": {
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "details": {
+            "$ref": "#/components/schemas/ApiKeyAutoErrorDetails"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyAutoChatRequestBody": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Your request in natural language"
+          },
+          "speed": {
+            "type": "string",
+            "enum": [
+              "fast",
+              "expert",
+              "adaptive"
+            ],
+            "description": "Response quality mode"
+          },
+          "sessionId": {
+            "type": "string",
+            "description": "Continue a previous conversation"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyValidateTradableSymbolResponse": {
+        "properties": {
+          "supported": {
+            "type": "string",
+            "enum": [
+              "true",
+              "false"
+            ],
+            "description": "Whether the symbol is tradable as a perpetual on the given exchange"
+          }
+        },
+        "required": [
+          "supported"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyValidateQueryResponse": {
+        "properties": {
+          "valid": {
+            "type": "boolean",
+            "description": "Whether the query is valid"
+          },
+          "errors": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              ]
+            },
+            "type": "array",
+            "description": "Validation errors (empty if valid)"
+          },
+          "warnings": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/JsonObject"
+                }
+              ]
+            },
+            "type": "array",
+            "description": "Validation warnings"
+          },
+          "estimatedCost": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Optional cost estimate"
+          },
+          "simulationLlmCallsEstimate": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Optional simulation details"
+          }
+        },
+        "required": [
+          "valid",
+          "errors",
+          "warnings"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyValidateQueryRequestBody": {
+        "properties": {
+          "query": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "EQL query to validate"
+          },
+          "title": {
+            "type": "string",
+            "description": "Optional title to validate alongside the query. Accepted so agents can\nvalidate the full create-query payload in one call. See\n{@link ApiKeyCreateQueryRequestBody.title}.",
+            "example": "BTC breakout alert",
+            "maxLength": 120
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description to validate alongside the query. See\n{@link ApiKeyCreateQueryRequestBody.description}.",
+            "example": "Notify when BTC is above 100k so I can review the breakout setup.",
+            "maxLength": 500
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyCreateQueryResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyCreateQueryRequestBody": {
+        "properties": {
+          "query": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "EQL query definition"
+          },
+          "title": {
+            "type": "string",
+            "description": "Short human-readable title for the query.\n\nSurfaced back in outbound notifications (Telegram, webhook, notify) so the\nrecipient immediately recognizes **what** fired — recipients often see an\nalert hours or days after the query was created. Strongly recommended for\nagent-built queries.",
+            "example": "BTC breakout alert",
+            "maxLength": 120
+          },
+          "description": {
+            "type": "string",
+            "description": "1–2 sentence description of the thesis or intent behind the trigger.\n\nSurfaced alongside the title in outbound notifications so the recipient\nunderstands **why** the trigger was set up. Write it as if the recipient\nhas forgotten they set this up — because they often have.",
+            "example": "Notify when BTC is above 100k so I can review the breakout setup.",
+            "maxLength": 500
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyAutoConditionValue": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number",
+            "format": "double"
+          },
+          {
+            "type": "boolean"
+          }
+        ],
+        "nullable": true
+      },
+      "ApiKeyAutoConditionState": {
+        "properties": {
+          "index": {
+            "type": "number",
+            "format": "double",
+            "description": "Zero-based condition index from the flattened EQL condition tree"
+          },
+          "source": {
+            "type": "string",
+            "description": "Data source that produced the value"
+          },
+          "method": {
+            "type": "string",
+            "description": "Source method that was evaluated"
+          },
+          "args": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Public condition arguments with internal source identifiers removed"
+          },
+          "currentValue": {
+            "$ref": "#/components/schemas/ApiKeyAutoConditionValue",
+            "description": "Latest observed value at evaluation time"
+          },
+          "targetValue": {
+            "$ref": "#/components/schemas/ApiKeyAutoConditionValue",
+            "description": "Threshold or comparison value from the EQL condition"
+          },
+          "operator": {
+            "type": "string",
+            "description": "Comparison operator"
+          },
+          "isMet": {
+            "type": "boolean",
+            "description": "Whether this condition was met in the latest evaluation"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO timestamp for the condition value"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Optional evaluator explanation or error reason"
+          },
+          "conversationSessionId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Linked LLM conversation session, when the condition used an LLM run"
+          },
+          "runId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Linked Auto/LLM run id, when available"
+          },
+          "cacheHit": {
+            "type": "boolean",
+            "description": "Whether the condition value came from cache"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyPollQueryLatestEvaluation": {
+        "properties": {
+          "evaluatedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO timestamp of the latest evaluation"
+          },
+          "conditionStates": {
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyAutoConditionState"
+            },
+            "type": "array",
+            "description": "Per-condition values from the latest evaluation snapshot"
+          },
+          "wouldTriggerNow": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Whether the latest evaluation would trigger at that time"
+          },
+          "matchingConditions": {
+            "type": "number",
+            "format": "double",
+            "nullable": true,
+            "description": "Number of conditions that matched in the latest evaluation"
+          },
+          "totalConditions": {
+            "type": "number",
+            "format": "double",
+            "nullable": true,
+            "description": "Total number of conditions evaluated"
+          }
+        },
+        "required": [
+          "evaluatedAt",
+          "conditionStates",
+          "wouldTriggerNow",
+          "matchingConditions",
+          "totalConditions"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyAutoExecutionDetails": {
+        "properties": {
+          "trade": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            ],
+            "nullable": true,
+            "description": "Trade action summary, when the execution placed or attempted an order"
+          },
+          "notification": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            ],
+            "nullable": true,
+            "description": "Notification/webhook/Telegram delivery summary, when applicable"
+          },
+          "llm": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            ],
+            "nullable": true,
+            "description": "LLM action summary, when applicable"
+          },
+          "auto": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            ],
+            "nullable": true,
+            "description": "Auto action summary, when applicable"
+          },
+          "script": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JsonObject"
+              }
+            ],
+            "nullable": true,
+            "description": "Script action summary, when applicable"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyAutoExecutionError": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true,
+            "description": "Stable error code"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true,
+            "description": "Human-readable error message"
+          }
+        },
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyAutoTriggerCondition": {
+        "properties": {
+          "source": {
+            "type": "string",
+            "description": "Data source that fired"
+          },
+          "method": {
+            "type": "string",
+            "description": "Source method that fired"
+          },
+          "args": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Public condition arguments with internal source identifiers removed"
+          },
+          "operator": {
+            "type": "string",
+            "description": "Comparison operator"
+          },
+          "value": {
+            "$ref": "#/components/schemas/ApiKeyAutoConditionValue",
+            "description": "Threshold or comparison value from the EQL condition"
+          }
+        },
+        "required": [
+          "source"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyAutoTriggerMatch": {
+        "properties": {
+          "observedValue": {
+            "$ref": "#/components/schemas/ApiKeyAutoConditionValue",
+            "description": "Numeric/string/boolean value observed when the trigger fired"
+          },
+          "url": {
+            "type": "string",
+            "description": "Public source URL for semantic tweet/news/Telegram matches, when available"
+          },
+          "mentionedAt": {
+            "type": "string",
+            "description": "Source event timestamp for semantic matches"
+          },
+          "confidence": {
+            "type": "number",
+            "format": "double",
+            "description": "Semantic match confidence, when available"
+          },
+          "accountHandle": {
+            "type": "string",
+            "description": "Public account handle for news/tweet matches, when available"
+          },
+          "chatUsername": {
+            "type": "string",
+            "description": "Public Telegram chat username, when available"
+          },
+          "chatTitle": {
+            "type": "string",
+            "description": "Public Telegram chat title, when available"
+          },
+          "messageId": {
+            "type": "string",
+            "description": "Public Telegram message id, when available"
+          },
+          "messageIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "description": "Public Telegram grouped message ids, when available"
+          },
+          "groupId": {
+            "type": "string",
+            "description": "Public Telegram group id, when available"
+          }
+        },
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyAutoMatchedCondition": {
+        "properties": {
+          "condition": {
+            "$ref": "#/components/schemas/ApiKeyAutoTriggerCondition",
+            "description": "Public condition definition that matched"
+          },
+          "match": {
+            "$ref": "#/components/schemas/ApiKeyAutoTriggerMatch",
+            "description": "Public match details, including observedValue for numeric conditions"
+          }
+        },
+        "required": [
+          "condition"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyAutoTriggerPayload": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Trigger category, e.g. price, poll, cron, or event"
+          },
+          "time": {
+            "type": "string",
+            "description": "ISO timestamp when the trigger fired"
+          },
+          "matchedConditions": {
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyAutoMatchedCondition"
+            },
+            "type": "array",
+            "description": "Conditions that were met when the trigger fired"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyPollQueryExecution": {
+        "properties": {
+          "triggerTime": {
+            "type": "string",
+            "description": "ISO timestamp when the Auto query fired"
+          },
+          "conditionsMet": {
+            "type": "number",
+            "format": "double",
+            "description": "Number of conditions met when the Auto query fired"
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/ApiKeyAutoTriggerPayload",
+            "description": "Canonical public trigger context for why the query fired"
+          },
+          "id": {
+            "type": "string",
+            "description": "Execution identifier"
+          },
+          "queryId": {
+            "type": "string",
+            "description": "Query identifier"
+          },
+          "type": {
+            "type": "string",
+            "description": "Execution type"
+          },
+          "status": {
+            "type": "string",
+            "description": "Execution status"
+          },
+          "details": {
+            "$ref": "#/components/schemas/ApiKeyAutoExecutionDetails",
+            "description": "Public execution details summary"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Execution creation timestamp"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApiKeyAutoExecutionError"
+              }
+            ],
+            "nullable": true,
+            "description": "Optional execution error object from Athena (when present)"
+          }
+        },
+        "required": [
+          "id",
+          "queryId",
+          "type",
+          "status",
+          "createdAt"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyPollQueryResponse": {
+        "properties": {
+          "queryId": {
+            "type": "string",
+            "description": "Query identifier"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current query status"
+          },
+          "latestEvaluation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApiKeyPollQueryLatestEvaluation"
+              }
+            ],
+            "nullable": true,
+            "description": "Latest condition evaluation snapshot"
+          },
+          "executions": {
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyPollQueryExecution"
+            },
+            "type": "array",
+            "description": "List of executions triggered by this query"
+          },
+          "credits": {
+            "type": "number",
+            "format": "double",
+            "description": "Aggregated LLM credits from sessions linked to this query"
+          }
+        },
+        "required": [
+          "queryId",
+          "status",
+          "latestEvaluation",
+          "executions"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyCancelQueryResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyDeleteQueryResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyAutoSessionSummary": {
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Session identifier"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true,
+            "description": "Session status"
+          },
+          "executedAt": {
+            "type": "string",
+            "description": "Execution timestamp"
+          }
+        },
+        "required": [
+          "sessionId",
+          "status",
+          "executedAt"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyListSessionsResponse": {
+        "properties": {
+          "queryId": {
+            "type": "string",
+            "description": "Query identifier"
+          },
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyAutoSessionSummary"
+            },
+            "type": "array",
+            "description": "List of LLM output sessions"
+          }
+        },
+        "required": [
+          "sessions"
+        ],
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyGetSessionResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyListQueriesResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyListQueryDraftsResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyGetQueryDraftResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyUpsertQueryDraftResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyUpsertQueryDraftRequestBody": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Optional draft identifier for update"
+          },
+          "query": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Draft query body"
+          },
+          "title": {
+            "type": "string",
+            "description": "Short human-readable title for the draft.\n\nCarried over when the draft is converted into an active query and then\nsurfaced in outbound notifications (Telegram, webhook, notify). Set this\nat draft time so downstream recipients know **what** the alert is about.",
+            "example": "BTC breakout alert",
+            "maxLength": 120
+          },
+          "description": {
+            "type": "string",
+            "description": "1–2 sentence description of the thesis or intent behind the draft.\n\nSurfaced alongside the title in outbound notifications once the draft is\nactivated. Write it as if the recipient has forgotten they set this up.",
+            "example": "Notify when BTC is above 100k so I can review the breakout setup.",
+            "maxLength": 500
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyDeleteQueryDraftResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyConvertQueryDraftResponse": {
+        "properties": {},
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "ApiKeyAutoExecution": {
+        "properties": {
+          "triggerTime": {
+            "type": "string",
+            "description": "ISO timestamp when the Auto query fired"
+          },
+          "conditionsMet": {
+            "type": "number",
+            "format": "double",
+            "description": "Number of conditions met when the Auto query fired"
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/ApiKeyAutoTriggerPayload",
+            "description": "Canonical public trigger context for why the query fired"
+          },
+          "id": {
+            "type": "string",
+            "description": "Execution identifier"
+          },
+          "queryId": {
+            "type": "string",
+            "description": "Query identifier"
+          },
+          "type": {
+            "type": "string",
+            "description": "Execution type"
+          },
+          "status": {
+            "type": "string",
+            "description": "Execution status"
+          },
+          "details": {
+            "$ref": "#/components/schemas/ApiKeyAutoExecutionDetails",
+            "description": "Public execution details summary"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ApiKeyAutoExecutionError"
+              }
+            ],
+            "nullable": true,
+            "description": "Optional execution error object from Athena (when present)"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Execution creation timestamp"
+          },
+          "auditDetails": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Full Athena audit details; returned by the single-execution endpoint"
+          },
+          "actionSnapshot": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Action configuration snapshot; returned by the single-execution endpoint"
+          },
+          "executionContext": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Execution context with user identity stripped"
+          },
+          "externalEvents": {
+            "items": {
+              "$ref": "#/components/schemas/JsonObject"
+            },
+            "type": "array",
+            "description": "External event records linked to the execution"
+          },
+          "notificationOutbox": {
+            "items": {
+              "$ref": "#/components/schemas/JsonObject"
+            },
+            "type": "array",
+            "description": "Sanitized notification outbox delivery metadata linked to the execution"
+          },
+          "schemaVersion": {
+            "type": "number",
+            "format": "double",
+            "description": "Execution schema version"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update timestamp"
+          },
+          "finishedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "Completion timestamp, if finished"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyAutoPagination": {
+        "properties": {
+          "total": {
+            "type": "number",
+            "format": "double",
+            "description": "Total matching records"
+          },
+          "limit": {
+            "type": "number",
+            "format": "double",
+            "description": "Page size"
+          },
+          "offset": {
+            "type": "number",
+            "format": "double",
+            "description": "Offset used for the page"
+          },
+          "hasMore": {
+            "type": "boolean",
+            "description": "Whether another page exists"
+          }
+        },
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyListExecutionsResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyAutoExecution"
+            },
+            "type": "array",
+            "description": "Execution records"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/ApiKeyAutoPagination",
+            "description": "Pagination metadata"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyGetExecutionResponse": {
+        "$ref": "#/components/schemas/ApiKeyAutoExecution"
+      },
+      "MercuryExchange": {
+        "type": "string",
+        "enum": [
+          "hyperliquid",
+          "gmx",
+          "binance",
+          "pacifica"
+        ]
+      },
+      "ApiKeyAutoExchange": {
+        "$ref": "#/components/schemas/MercuryExchange"
+      },
+      "ApiKeyExchangeConnection": {
+        "properties": {
+          "exchange": {
+            "$ref": "#/components/schemas/ApiKeyAutoExchange",
+            "description": "Exchange identifier"
+          },
+          "credentialType": {
+            "type": "string",
+            "description": "Credential strategy identifier"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Exchange-specific metadata"
+          },
+          "isActive": {
+            "type": "boolean",
+            "description": "Whether the connection is currently active"
+          },
+          "id": {
+            "type": "number",
+            "format": "double",
+            "description": "Connection identifier"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update timestamp"
+          }
+        },
+        "required": [
+          "exchange",
+          "credentialType",
+          "metadata",
+          "isActive",
+          "id",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyListExchangesResponse": {
+        "properties": {
+          "connections": {
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyExchangeConnection"
+            },
+            "type": "array",
+            "description": "Active exchange connections for the linked Auto user"
+          }
+        },
+        "required": [
+          "connections"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyConnectExchangeResponse": {
+        "$ref": "#/components/schemas/ApiKeyExchangeConnection"
+      },
+      "ApiKeyConnectHyperliquidExchangeRequestBody": {
+        "properties": {
+          "exchange": {
+            "type": "string",
+            "enum": [
+              "hyperliquid"
+            ],
+            "nullable": false,
+            "description": "Exchange identifier"
+          },
+          "credentialType": {
+            "type": "string",
+            "description": "Credential strategy identifier, e.g. `agent_wallet`"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Exchange-specific metadata such as owner/agent addresses"
+          },
+          "credentials": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Optional metadata-only passthrough; wallet venues are not ccxt-custodied here"
+          }
+        },
+        "required": [
+          "exchange",
+          "credentialType"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyConnectGmxExchangeRequestBody": {
+        "properties": {
+          "exchange": {
+            "type": "string",
+            "enum": [
+              "gmx"
+            ],
+            "nullable": false,
+            "description": "Exchange identifier"
+          },
+          "credentialType": {
+            "type": "string",
+            "description": "Credential strategy identifier, e.g. `agent_wallet`"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Exchange-specific metadata such as owner/agent addresses"
+          },
+          "credentials": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Optional metadata-only passthrough; wallet venues are not ccxt-custodied here"
+          }
+        },
+        "required": [
+          "exchange",
+          "credentialType"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyConnectBinanceExchangeRequestBody": {
+        "properties": {
+          "exchange": {
+            "type": "string",
+            "enum": [
+              "binance"
+            ],
+            "nullable": false,
+            "description": "Exchange identifier"
+          },
+          "credentialType": {
+            "type": "string",
+            "description": "Credential strategy identifier, e.g. `api_key`"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Optional caller metadata mirrored back on reads"
+          },
+          "credentials": {
+            "properties": {
+              "secret": {
+                "type": "string",
+                "description": "API secret"
+              },
+              "apiKey": {
+                "type": "string",
+                "description": "API key"
+              }
+            },
+            "required": [
+              "secret",
+              "apiKey"
+            ],
+            "type": "object",
+            "description": "Binance API credentials"
+          }
+        },
+        "required": [
+          "exchange",
+          "credentialType",
+          "credentials"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyConnectPacificaExchangeRequestBody": {
+        "properties": {
+          "exchange": {
+            "type": "string",
+            "enum": [
+              "pacifica"
+            ],
+            "nullable": false,
+            "description": "Exchange identifier"
+          },
+          "credentialType": {
+            "type": "string",
+            "description": "Credential strategy identifier, e.g. `wallet`"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/JsonObject",
+            "description": "Optional caller metadata mirrored back on reads"
+          },
+          "credentials": {
+            "properties": {
+              "walletAddress": {
+                "type": "string",
+                "description": "Pacifica trading wallet address"
+              },
+              "privateKey": {
+                "type": "string",
+                "description": "Base58 Solana private key"
+              }
+            },
+            "required": [
+              "walletAddress",
+              "privateKey"
+            ],
+            "type": "object",
+            "description": "Pacifica trading wallet credentials"
+          }
+        },
+        "required": [
+          "exchange",
+          "credentialType",
+          "credentials"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ApiKeyConnectExchangeRequestBody": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/ApiKeyConnectHyperliquidExchangeRequestBody"
+          },
+          {
+            "$ref": "#/components/schemas/ApiKeyConnectGmxExchangeRequestBody"
+          },
+          {
+            "$ref": "#/components/schemas/ApiKeyConnectBinanceExchangeRequestBody"
+          },
+          {
+            "$ref": "#/components/schemas/ApiKeyConnectPacificaExchangeRequestBody"
+          }
+        ]
+      },
+      "ApiKeyDisconnectExchangeResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "nullable": false,
+            "description": "Whether the disconnect succeeded"
+          }
+        },
+        "required": [
+          "success"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "Pick_ChatRequestBodyV2.Exclude_keyofChatRequestBodyV2.speed__": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "The user message. Required when analysisType is \"chat\"; ignored for all other analysis types."
+          },
+          "sessionId": {
+            "type": "string",
+            "description": "Omit to start a new conversation. Pass the sessionId from a previous response to continue an existing conversation."
+          },
+          "analysisType": {
+            "type": "string",
+            "enum": [
+              "chat",
+              "macro",
+              "summary",
+              "tokenIntro",
+              "tokenAnalysis",
+              "accountAnalysis"
+            ],
+            "description": "The type of analysis to perform. Defaults to \"chat\".\n- `chat` — conversational AI. Requires `message`.\n- `macro` — macro market overview.\n- `summary` — quick market summary.\n- `tokenIntro` — token introduction. Requires `assetMetadata`.\n- `tokenAnalysis` — in-depth token analysis. Requires `assetMetadata`.\n- `accountAnalysis` — Twitter/X account analysis. Requires `assetMetadata.username`.",
+            "default": "chat"
+          },
+          "assetMetadata": {
+            "$ref": "#/components/schemas/ChatAssetMetadataV2",
+            "description": "Required for tokenIntro, tokenAnalysis, and accountAnalysis. See endpoint description for required fields per analysis type."
+          }
+        },
+        "type": "object",
+        "description": "From T, pick a set of properties whose keys are in the union K"
+      },
+      "Omit_ChatRequestBodyV2.speed_": {
+        "$ref": "#/components/schemas/Pick_ChatRequestBodyV2.Exclude_keyofChatRequestBodyV2.speed__",
+        "description": "Construct a type with the properties of T except for those in type K."
+      },
+      "X402ChatRequestBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Omit_ChatRequestBodyV2.speed_"
+          },
+          {
+            "properties": {
+              "speed": {
+                "type": "string",
+                "enum": [
+                  "fast",
+                  "expert"
+                ]
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "description": "Same shape as `/v2/chat`; `speed` excludes `adaptive` on x402 (see `X402_CONFIG.ADAPTIVE_SPEED_ENABLED`)."
+      },
+      "AutoChatResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "data": {
+            "properties": {
+              "creditsConsumed": {
+                "type": "number",
+                "format": "double",
+                "description": "Number of credits consumed"
+              },
+              "sessionId": {
+                "type": "string",
+                "description": "Session ID for continuing this conversation"
+              },
+              "message": {
+                "type": "string",
+                "description": "AI response in Markdown. EQL will be in a JSON code block when generated."
+              }
+            },
+            "required": [
+              "creditsConsumed",
+              "sessionId",
+              "message"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "success",
+          "data"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "X402ErrorResponse": {
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "AutoChatRequestBody": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Your request in natural language"
+          },
+          "speed": {
+            "type": "string",
+            "enum": [
+              "fast",
+              "expert"
+            ],
+            "description": "Response quality mode"
+          },
+          "sessionId": {
+            "type": "string",
+            "description": "Continue a previous conversation"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ValidationIssue": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "additionalProperties": {}
+      },
+      "CostEstimate": {
+        "properties": {
+          "credits": {
+            "type": "number",
+            "format": "double",
+            "description": "Approximate credits equivalent (rounded to whole credits)"
+          },
+          "price": {
+            "type": "string",
+            "description": "Exact price in USD (e.g. \"$1.045\")"
+          }
+        },
+        "required": [
+          "credits",
+          "price"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "SimulationLlmCallsEstimate": {
+        "properties": {
+          "conditionCallsUpperBound": {
+            "type": "number",
+            "format": "double"
+          },
+          "actionCallsUpperBound": {
+            "type": "number",
+            "format": "double"
+          },
+          "conditionCallsBySpeed": {
+            "properties": {
+              "adaptive": {
+                "type": "number",
+                "format": "double"
+              },
+              "expert": {
+                "type": "number",
+                "format": "double"
+              },
+              "fast": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "adaptive",
+              "expert",
+              "fast"
+            ],
+            "type": "object"
+          },
+          "actionCallsBySpeed": {
+            "properties": {
+              "adaptive": {
+                "type": "number",
+                "format": "double"
+              },
+              "expert": {
+                "type": "number",
+                "format": "double"
+              },
+              "fast": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "adaptive",
+              "expert",
+              "fast"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "conditionCallsUpperBound",
+          "actionCallsUpperBound",
+          "conditionCallsBySpeed",
+          "actionCallsBySpeed"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ValidateQueryResponse": {
+        "properties": {
+          "valid": {
+            "type": "boolean",
+            "description": "Whether the query is valid"
+          },
+          "errors": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/ValidationIssue"
+                }
+              ]
+            },
+            "type": "array",
+            "description": "Validation errors (empty if valid)"
+          },
+          "warnings": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/ValidationIssue"
+                }
+              ]
+            },
+            "type": "array",
+            "description": "Validation warnings"
+          },
+          "estimatedCost": {
+            "$ref": "#/components/schemas/CostEstimate",
+            "description": "Estimated cost (included when valid)"
+          },
+          "simulationLlmCallsEstimate": {
+            "$ref": "#/components/schemas/SimulationLlmCallsEstimate",
+            "description": "LLM call simulation breakdown"
+          }
+        },
+        "required": [
+          "valid",
+          "errors",
+          "warnings"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "EqlActionStep": {
+        "properties": {
+          "stepId": {
+            "type": "string",
+            "description": "Deterministic step id (Athena requires exactly one action step)"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "webhook",
+              "notify",
+              "telegram_bot",
+              "llm"
+            ],
+            "description": "Action type to execute when conditions are met"
+          },
+          "params": {
+            "$ref": "#/components/schemas/Record_string.unknown_",
+            "description": "Action parameters"
+          }
+        },
+        "required": [
+          "stepId",
+          "type",
+          "params"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "EqlQuery": {
+        "properties": {
+          "conditions": {
+            "$ref": "#/components/schemas/Record_string.unknown_",
+            "description": "Condition tree (typically an AND/OR object)"
+          },
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/EqlActionStep"
+            },
+            "type": "array",
+            "description": "Exactly one action step"
+          },
+          "expiresIn": {
+            "type": "string",
+            "description": "Duration until query expires (e.g. \"30m\", \"2h\", \"24h\", \"7d\")"
+          }
+        },
+        "required": [
+          "conditions",
+          "actions",
+          "expiresIn"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ValidateQueryRequestBody": {
+        "properties": {
+          "query": {
+            "$ref": "#/components/schemas/EqlQuery",
+            "description": "EQL query to validate"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CreateQueryResponse": {
+        "properties": {
+          "queryId": {
+            "type": "string",
+            "description": "Unique query identifier"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current query status"
+          },
+          "cost": {
+            "$ref": "#/components/schemas/CostEstimate",
+            "description": "Cost charged for query creation"
+          }
+        },
+        "required": [
+          "queryId",
+          "status"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CreateQueryRequestBody": {
+        "properties": {
+          "query": {
+            "$ref": "#/components/schemas/EqlQuery",
+            "description": "EQL query definition"
+          },
+          "title": {
+            "type": "string",
+            "description": "Short human-readable title for the query.\n\nSurfaced back in outbound notifications (Telegram, webhook, notify) so the\nrecipient immediately recognizes **what** fired — recipients often see an\nalert hours or days after the query was created. Strongly recommended for\nagent-built queries.",
+            "example": "BTC breakout alert",
+            "maxLength": 120
+          },
+          "description": {
+            "type": "string",
+            "description": "1–2 sentence description of the thesis or intent behind the trigger.\n\nSurfaced alongside the title in outbound notifications so the recipient\nunderstands **why** the trigger was set up. Write it as if the recipient\nhas forgotten they set this up — because they often have.",
+            "example": "Notify when BTC is above 100k so I can review the breakout setup.",
+            "maxLength": 500
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "PollQueryLatestEvaluation": {
+        "properties": {
+          "evaluatedAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO timestamp of the latest evaluation"
+          },
+          "conditionStates": {
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyAutoConditionState"
+            },
+            "type": "array",
+            "description": "Per-condition values from the latest evaluation snapshot"
+          },
+          "wouldTriggerNow": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Whether the latest evaluation would trigger at that time"
+          },
+          "matchingConditions": {
+            "type": "number",
+            "format": "double",
+            "nullable": true,
+            "description": "Number of conditions that matched in the latest evaluation"
+          },
+          "totalConditions": {
+            "type": "number",
+            "format": "double",
+            "nullable": true,
+            "description": "Total number of conditions evaluated"
+          }
+        },
+        "required": [
+          "evaluatedAt",
+          "conditionStates",
+          "wouldTriggerNow",
+          "matchingConditions",
+          "totalConditions"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "PollQueryExecution": {
+        "$ref": "#/components/schemas/ApiKeyPollQueryExecution"
+      },
+      "PollQueryResponse": {
+        "properties": {
+          "queryId": {
+            "type": "string",
+            "description": "Query identifier"
+          },
+          "status": {
+            "type": "string",
+            "description": "Current query status"
+          },
+          "latestEvaluation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PollQueryLatestEvaluation"
+              }
+            ],
+            "nullable": true,
+            "description": "Latest condition evaluation snapshot"
+          },
+          "executions": {
+            "items": {
+              "$ref": "#/components/schemas/PollQueryExecution"
+            },
+            "type": "array",
+            "description": "List of executions triggered by this query"
+          }
+        },
+        "required": [
+          "queryId",
+          "status",
+          "latestEvaluation",
+          "executions"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "CancelQueryResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Query identifier"
+          },
+          "status": {
+            "type": "string",
+            "description": "Updated status"
+          },
+          "cancelledAt": {
+            "type": "string",
+            "description": "Timestamp of cancellation"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "cancelledAt"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "SessionSummary": {
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Session identifier"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true,
+            "description": "Session status"
+          },
+          "executedAt": {
+            "type": "string",
+            "description": "When the session was executed"
+          }
+        },
+        "required": [
+          "sessionId",
+          "status",
+          "executedAt"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "ListSessionsResponse": {
+        "properties": {
+          "queryId": {
+            "type": "string",
+            "description": "Query identifier"
+          },
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/SessionSummary"
+            },
+            "type": "array",
+            "description": "List of LLM output sessions"
+          }
+        },
+        "required": [
+          "queryId",
+          "sessions"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "SessionMessage": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "nullable": true
+          },
+          "response": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "analysisType": {
+            "type": "string",
+            "nullable": true
+          },
+          "timestamp": {
+            "type": "string",
+            "nullable": true
+          },
+          "trades": {
+            "items": {},
+            "type": "array"
+          }
+        },
+        "required": [
+          "query",
+          "response",
+          "status",
+          "analysisType",
+          "timestamp",
+          "trades"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      },
+      "GetSessionResponse": {
+        "properties": {
+          "sessionId": {
+            "type": "string",
+            "description": "Session identifier"
+          },
+          "queryId": {
+            "type": "string",
+            "description": "Query identifier"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true,
+            "description": "Session title"
+          },
+          "analysisType": {
+            "type": "string",
+            "nullable": true,
+            "description": "Analysis type"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "When the session was created"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/SessionMessage"
+            },
+            "type": "array",
+            "description": "Conversation messages"
+          }
+        },
+        "required": [
+          "sessionId",
+          "queryId",
+          "title",
+          "analysisType",
+          "createdAt",
+          "messages"
+        ],
+        "type": "object",
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "x-elfa-api-key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/providers/elfa-ai/api/openapi.json
+++ b/providers/elfa-ai/api/openapi.json
@@ -1184,7 +1184,7 @@
             "description": "Payment required (x402)"
           }
         },
-        "description": "Send a message to Elfa AI and receive a complete response.\n\n`message` is required for `analysisType: \"chat\"` and ignored for other\nanalysis types. `adaptive` speed is not available on x402.\n\n**Cost:** speed based (`fast` 5 credits/$0.045, `expert` 18 credits/$0.162).\nRequires x402 payment.",
+        "description": "Send a message to Elfa AI and receive a complete response.\n\n`message` is required for `analysisType: \"chat\"` and ignored for other\nanalysis types. `adaptive` speed is not available on x402.\n\n**Cost:** speed based, charged with the `exact` scheme (`fast` $1, `expert` $2). Requires x402 payment.",
         "summary": "Generate an AI answer about crypto markets",
         "tags": [
           "x402 Chat"
@@ -1227,7 +1227,7 @@
                   "scale": 1,
                   "tiers": [
                     {
-                      "price_usd": 0.045
+                      "price_usd": 1
                     }
                   ]
                 }
@@ -1243,7 +1243,7 @@
                   "scale": 1,
                   "tiers": [
                     {
-                      "price_usd": 0.162
+                      "price_usd": 2
                     }
                   ]
                 }
@@ -1294,7 +1294,7 @@
             "description": "Payment required (x402)"
           }
         },
-        "description": "Ask the AI to help you build an EQL query. It can research live market data, suggest strategies, and return ready-to-use EQL JSON.\n\nThe response message contains the AI's reply in Markdown. When it generates EQL,\nit will be in a JSON code block that you can extract, validate, and submit.\n\nUse `sessionId` in follow-up requests to maintain conversation context.\n\n**Cost:** speed based (`fast` 5 credits/$0.045, `expert` 18 credits/$0.162).\nRequires x402 payment.",
+        "description": "Ask the AI to help you build an EQL query. It can research live market data, suggest strategies, and return ready-to-use EQL JSON.\n\nThe response message contains the AI's reply in Markdown. When it generates EQL,\nit will be in a JSON code block that you can extract, validate, and submit.\n\nUse `sessionId` in follow-up requests to maintain conversation context.\n\n**Cost:** speed based, charged with the `exact` scheme (`fast` $1, `expert` $2). Requires x402 payment.",
         "summary": "Generate an Auto plan from a prompt",
         "tags": [
           "x402 Auto"
@@ -1337,7 +1337,7 @@
                   "scale": 1,
                   "tiers": [
                     {
-                      "price_usd": 0.045
+                      "price_usd": 1
                     }
                   ]
                 }
@@ -1353,7 +1353,7 @@
                   "scale": 1,
                   "tiers": [
                     {
-                      "price_usd": 0.162
+                      "price_usd": 2
                     }
                   ]
                 }
@@ -4735,7 +4735,31 @@
               "expert",
               "fast"
             ],
-            "type": "object"
+            "type": "object",
+            "description": "All credit-consuming action fires (`llm` + `auto`) by speed."
+          },
+          "autoActionCallsBySpeed": {
+            "properties": {
+              "adaptive": {
+                "type": "number",
+                "format": "double"
+              },
+              "expert": {
+                "type": "number",
+                "format": "double"
+              },
+              "fast": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "adaptive",
+              "expert",
+              "fast"
+            ],
+            "type": "object",
+            "description": "Subset of `actionCallsBySpeed` that are top-level `auto` fires.\nPriced at Auto agent rates (full builder session), not single LLM-call rates."
           }
         },
         "required": [


### PR DESCRIPTION
Adds **Elfa AI** (`elfa-ai/api`).

Elfa is real-time data infrastructure for financial AI, powered by our intelligence stack **Iris**. Iris synthesises signals across social, on-chain and off-chain market data, then traces their second and third-order effects, so agents act on greater context.

These endpoints serve the same signals our own finance agent runs on, pay-per-call over x402 — no API key and no account. We run them ourselves at `https://api.elfa.ai`, no gateway in front.

## Auto — the condition engine

The part we expect agents to reach for most. Describe what to watch and Elfa fires a webhook when it happens: register an EQL query against price or social conditions, and it is evaluated continuously. Identity is `SHA256(x-elfa-agent-secret)`, so an agent invents a secret once and reuses it to reach its own queries.

Creating a query is the only paid step — validating, polling, cancelling, listing LLM sessions and the SSE notification stream are free.

## Iris market intelligence

Point-in-time reads of what the market is saying and doing: trending assets and contract addresses surfacing on X and Telegram, smart-account stats, keyword mention feeds, token news, event summaries and narratives, plus an LLM chat endpoint that interprets them.

## Payment

- USDC on **Solana mainnet** (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`), plus Base, Arbitrum, Polygon and Avalanche — every rail is quoted in the same 402, so the caller pays on whichever they already hold.
- Solana payments are gasless; the facilitator acts as fee payer.
- x402 v2, `exact` scheme, challenge in the `PAYMENT-REQUIRED` header.

## Endpoints

18 total — twelve paid, six free.

| Price | Endpoints |
|---|---|
| $0.09 / $0.207 | Auto query creation, by `speed` |
| free | Auto validate, poll, cancel, list sessions, session detail, SSE stream |
| $0.045 / $0.162 | LLM chat and Auto builder chat, by `speed` |
| $0.045 | event summary, trending narratives |
| $0.009 | trending tokens, trending contract addresses (X / Telegram), smart-account stats, keyword mentions, token news, top mentions |

## Notes for reviewers

**Auto query pricing is dynamic.** `POST /x402/v2/auto/queries` costs a $0.045 baseline plus each simulated LLM call the query needs ($0.045 fast, $0.162 expert). The listed variants describe the common single-call case rather than a floor or ceiling. `PAY.md` says so and points callers at the free `validate` endpoint, which returns the exact cost before anything is created. Happy to express this differently if you would rather see the baseline advertised.

**The six free Auto endpoints carry explicit `price_usd: 0` variants.** They are identity-scoped on an `x-elfa-agent-secret` header, so an unauthenticated probe cannot classify them. The zero-priced variants are what let them publish honestly instead of being dropped.

**The spec is generated, not hand-maintained.** `openapi.json` is produced from the same price table our payment middleware charges from, so the advertised price cannot drift from what we bill. Refreshing it is a single command on our side.

## Checks

```
pay catalog check . --changed-from origin/main
│ Changed providers check successful
│ 18 endpoints tested across 1 provider
│ 11/11 gates compatible with Solana
```

`pay catalog check providers/elfa/api/PAY.md --strict` is also clean, with zero static warnings.
