### PR TITLE
feat(catalog): add bykaranteli/derivatives

### DIFF
--- a/providers/bykaranteli/derivatives/PAY.md
+++ b/providers/bykaranteli/derivatives/PAY.md
@@ -1,0 +1,43 @@
+---
+name: derivatives
+title: "ByKaranteli Derivatives Data"
+description: "Crypto derivatives market structure from a continuous recorder: multi-exchange liquidation maps with modeled clusters and real forceOrder levels, Deribit options premium flow with big prints, and VPIN order-flow toxicity history."
+use_case: "Use for liquidation levels and magnets around a perp price, options tape history and large premium prints, or order-flow toxicity before sizing a position. Also use when a live snapshot is not enough and the task needs recorded history."
+category: finance
+service_url: https://bykaranteli.com
+openapi:
+  path: openapi.json
+---
+
+Derivatives market structure recorded around the clock and sold per call. Three
+paid endpoints, all `GET`, all answering `402` with an x402 v2 challenge:
+
+| Endpoint | Price | Returns |
+|---|---|---|
+| `/api/x402/liqmap-levels` | $0.005 | Liquidation map for one Binance USDT-M perp: modeled leverage clusters plus real `forceOrder` levels aggregated across Binance, Bybit, OKX, Gate, HTX and Hyperliquid, top magnets, funding, OI and orderbook context. |
+| `/api/x402/options-flow` | $0.005 | Deribit BTC or ETH options tape: daily premium-flow history plus the full big-print list. |
+| `/api/x402/flow-vpin` | $0.002 | VPIN order-flow toxicity for BTC, ETH and SOL: 90-day daily track plus the last 500 volume buckets. |
+
+Payment: USDC on **Solana mainnet** (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`)
+or on Base mainnet, same amount either way, settled through the PayAI
+facilitator. No account, no signup, no API key. `GET /api/x402` is free and
+returns the machine-readable catalog of prices and rails.
+
+Every paid endpoint has a free counterpart under `/api/public/*` that carries
+the live snapshot. What is sold here is depth and history, not the current
+value.
+
+## Spend-aware usage
+
+- Check the free snapshot first. `/api/public/flow` already answers "how toxic
+  is flow right now"; pay for `/api/x402/flow-vpin` only when the task needs the
+  90-day track or the bucket series behind it.
+- `/api/public/options-flow` covers the last 24h of Deribit premium flow for
+  free. Reach for the paid endpoint when the question is about history or about
+  the full big-print list.
+- One symbol per liquidation-map call. `symbol=BTCUSDT` is the default; pass
+  `exchange=` to narrow to a single venue instead of paying twice to compare.
+- Liquidation maps move with price, not with the clock. Re-fetching the same
+  symbol inside a few minutes usually buys the same clusters again.
+- `flow-vpin` returns BTC, ETH and SOL in one response. Do not call it once per
+  symbol.

--- a/providers/bykaranteli/derivatives/PAY.md
+++ b/providers/bykaranteli/derivatives/PAY.md
@@ -1,29 +1,40 @@
 ---
 name: derivatives
 title: "ByKaranteli Derivatives Data"
-description: "Crypto derivatives market structure from a continuous recorder: multi-exchange liquidation maps with modeled clusters and real forceOrder levels, Deribit options premium flow with big prints, and VPIN order-flow toxicity history."
-use_case: "Use for liquidation levels and magnets around a perp price, options tape history and large premium prints, or order-flow toxicity before sizing a position. Also use when a live snapshot is not enough and the task needs recorded history."
+description: "Crypto derivatives market structure from a continuous recorder: multi-exchange liquidation maps and raw liquidation events, funding and open-interest history, Deribit options tape and open interest, DVOL, CFTC COT, Coinbase premium and VPIN."
+use_case: "Use for liquidation levels around a perp price, funding or open-interest history, options tape and positioning, COT or Coinbase premium series, execution slippage, or order-flow toxicity when the task needs recorded history, not a live snapshot."
 category: finance
 service_url: https://bykaranteli.com
 openapi:
   path: openapi.json
 ---
 
-Derivatives market structure recorded around the clock and sold per call. Three
-paid endpoints, all `GET`, all answering `402` with an x402 v2 challenge:
+Derivatives market structure recorded around the clock and sold per call.
+Thirteen paid endpoints, all `GET`, all answering `402` with an x402 v2
+challenge:
 
 | Endpoint | Price | Returns |
 |---|---|---|
 | `/api/x402/liqmap-levels` | $0.005 | Liquidation map for one Binance USDT-M perp: modeled leverage clusters plus real `forceOrder` levels aggregated across Binance, Bybit, OKX, Gate, HTX and Hyperliquid, top magnets, funding, OI and orderbook context. |
+| `/api/x402/liquidations-raw` | $0.010 | Individual liquidation events recorded from our own Binance, Bybit and OKX sockets: side, price, quantity, notional, venue and millisecond timestamp. |
+| `/api/x402/funding-history` | $0.005 | Settled funding rate history per symbol and venue, the series behind carry and basis work. |
+| `/api/x402/oi-history` | $0.005 | Five-minute open-interest history for the major perpetuals, in base units and USD, normalised across symbols. |
 | `/api/x402/options-flow` | $0.005 | Deribit BTC or ETH options tape: daily premium-flow history plus the full big-print list. |
+| `/api/x402/options-oi-history` | $0.005 | Daily listed options open interest per instrument: strike, expiry, type, OI, mark IV, underlying price and traded notional. |
+| `/api/x402/dvol-history` | $0.002 | Daily BTC and ETH implied-volatility index history back to 2021. |
 | `/api/x402/flow-vpin` | $0.002 | VPIN order-flow toxicity for BTC, ETH and SOL: 90-day daily track plus the last 500 volume buckets. |
+| `/api/x402/spot-microstructure` | $0.010 | Minute bars with the taker-buy versus total quote-volume split, pre-joined across venues and kept beyond exchange retention. |
+| `/api/x402/slippage-history` | $0.002 | Hourly recorded execution-slippage ladders per symbol: what a given order size would have cost against the live book. |
+| `/api/x402/premium-history` | $0.005 | Daily Coinbase premium history: Coinbase versus offshore price spread, with both leg prices. |
+| `/api/x402/cot-history` | $0.005 | Weekly CFTC Commitments of Traders history for CME crypto futures, per trader category, plus open interest per report. |
+| `/api/x402/listings-history` | $0.002 | Perpetual listing and delisting events across six exchanges, with first-seen, last-seen and delisted timestamps. |
 
 Payment: USDC on **Solana mainnet** (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`)
-or on Base mainnet, same amount either way, settled through the PayAI
+or on Base mainnet, same amount either way, settled through the Coinbase CDP
 facilitator. No account, no signup, no API key. `GET /api/x402` is free and
 returns the machine-readable catalog of prices and rails.
 
-Every paid endpoint has a free counterpart under `/api/public/*` that carries
+Most paid endpoints have a free counterpart under `/api/public/*` that carries
 the live snapshot. What is sold here is depth and history, not the current
 value.
 
@@ -41,3 +52,7 @@ value.
   symbol inside a few minutes usually buys the same clusters again.
 - `flow-vpin` returns BTC, ETH and SOL in one response. Do not call it once per
   symbol.
+- The history endpoints take a date or lookback range. Ask for the widest range
+  the task needs in one call rather than paging day by day.
+- `cot-history` is weekly and `dvol-history`, `premium-history` and
+  `listings-history` are daily. Re-fetching them intraday buys the same rows.

--- a/providers/bykaranteli/derivatives/openapi.json
+++ b/providers/bykaranteli/derivatives/openapi.json
@@ -36,7 +36,7 @@
     "/api/x402/liqmap-levels": {
       "get": {
         "summary": "Fetch the multi-exchange liquidation map for one perp",
-        "description": "Full liquidation map snapshot for a Binance USDT-M perp: modeled leverage clusters, real forceOrder levels aggregated across Binance, Bybit, OKX, Gate, HTX and Hyperliquid, top magnets, funding, open interest and orderbook context.",
+        "description": "Full multi-exchange liquidation map snapshot for a Binance USDT-M perp: modeled leverage clusters, real forceOrder levels, top magnets, funding, OI and orderbook context.",
         "operationId": "liqmap-levels",
         "responses": {
           "200": {
@@ -68,7 +68,7 @@
     "/api/x402/options-flow": {
       "get": {
         "summary": "Fetch Deribit options tape history and big prints",
-        "description": "BTC or ETH options tape depth from recorded Deribit flow: daily premium-flow history plus the full big-print list. The 24h summary alone is unmetered at /api/public/options-flow.",
+        "description": "BTC or ETH options tape depth from recorded Deribit flow: daily premium-flow history plus the full big-print list.",
         "operationId": "options-flow",
         "responses": {
           "200": {
@@ -100,7 +100,7 @@
     "/api/x402/flow-vpin": {
       "get": {
         "summary": "Fetch VPIN order-flow toxicity history for BTC, ETH, SOL",
-        "description": "Order flow toxicity (VPIN) history for BTC, ETH and SOL in one response: 90-day daily VPIN track with closes plus the last 500 volume buckets. The live snapshot alone is unmetered at /api/public/flow.",
+        "description": "Order flow toxicity (VPIN) history for BTC, ETH and SOL: 90-day daily track plus the last 500 volume buckets.",
         "operationId": "flow-vpin",
         "responses": {
           "200": {
@@ -120,6 +120,326 @@
             "mode": "fixed",
             "currency": "USD",
             "amount": "0.002000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/premium-history": {
+      "get": {
+        "summary": "Fetch daily Coinbase premium history for BTC and ETH",
+        "description": "Daily Coinbase premium history: the Coinbase versus offshore price spread per day, the classic read on United States spot demand, with both leg prices.",
+        "operationId": "premium-history",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/cot-history": {
+      "get": {
+        "summary": "Fetch CFTC Commitments of Traders history for crypto futures",
+        "description": "Full CFTC Commitments of Traders weekly history for crypto futures: dealer, asset manager, leveraged fund, other reportable and non reportable long and short positions plus open interest per report.",
+        "operationId": "cot-history",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/liquidations-raw": {
+      "get": {
+        "summary": "Fetch individual recorded liquidation events per venue",
+        "description": "Individual liquidation events recorded from our own exchange sockets across Binance, Bybit and OKX: side, price, quantity, notional, venue and millisecond timestamp.",
+        "operationId": "liquidations-raw",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.010000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/oi-history": {
+      "get": {
+        "summary": "Fetch 5-minute open interest history for major perps",
+        "description": "Five minute open interest history for the major perpetuals in base units and USD, normalised across symbols and retained on our side, so one query replaces per-symbol paginated pulls against exchange endpoints.",
+        "operationId": "oi-history",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/funding-history": {
+      "get": {
+        "summary": "Fetch settled funding rate history per symbol and venue",
+        "description": "Settled funding rate history per symbol and venue, the series behind carry and basis work.",
+        "operationId": "funding-history",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/options-oi-history": {
+      "get": {
+        "summary": "Fetch daily listed options open interest per instrument",
+        "description": "Daily listed options open interest per instrument: strike, expiry, option type, open interest, mark implied volatility, underlying price and traded notional.",
+        "operationId": "options-oi-history",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/dvol-history": {
+      "get": {
+        "summary": "Fetch daily BTC and ETH implied volatility index history",
+        "description": "Daily implied volatility index history for BTC and ETH going back to 2021, the crypto equivalent of a VIX series.",
+        "operationId": "dvol-history",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/slippage-history": {
+      "get": {
+        "summary": "Fetch hourly execution slippage ladders per symbol",
+        "description": "Hourly recorded execution slippage ladders per symbol: what a given order size would actually cost against the live book at that hour.",
+        "operationId": "slippage-history",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/listings-history": {
+      "get": {
+        "summary": "Fetch perpetual listing and delisting event history",
+        "description": "Perpetual listing and delisting events across six exchanges with first seen, last seen and delisted timestamps per instrument, the record behind listing driven volatility studies.",
+        "operationId": "listings-history",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/spot-microstructure": {
+      "get": {
+        "summary": "Fetch minute bars with the taker-buy quote volume split",
+        "description": "Minute bars with the taker buy versus total quote volume split, pre-joined across venues and kept beyond exchange retention: the raw input behind order flow imbalance and VPIN work, in one query instead of paginating an exchange API per symbol per venue.",
+        "operationId": "spot-microstructure",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.010000"
           },
           "networks": [
             "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",

--- a/providers/bykaranteli/derivatives/openapi.json
+++ b/providers/bykaranteli/derivatives/openapi.json
@@ -1,0 +1,133 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "ByKaranteli crypto derivatives data",
+    "version": "1.0.0",
+    "description": "Crypto derivatives market structure recorded around the clock. The live snapshots are free and unmetered; the endpoints listed here sell depth and history per call over the x402 protocol.",
+    "x-guidance": "Free endpoints under /api/public/* need no payment or key. The /api/x402/* endpoints answer HTTP 402 with machine-readable payment requirements and settle in USDC on Solana or Base per successful response. A failed response settles nothing.",
+    "contact": {
+      "email": "support@bykaranteli.com",
+      "url": "https://bykaranteli.com/developers"
+    },
+    "license": {
+      "name": "Data: CC0 for published datasets",
+      "url": "https://bykaranteli.com/data"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://bykaranteli.com"
+    }
+  ],
+  "paths": {
+    "/api/x402": {
+      "get": {
+        "summary": "List paid endpoints, prices and settlement rails",
+        "description": "Machine-readable catalog of the paid endpoints: per-call price in USD, the accepted settlement networks and the pay-to addresses. No payment required.",
+        "operationId": "x402Catalog",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Catalog of paid endpoints, prices and settlement rails"
+          }
+        }
+      }
+    },
+    "/api/x402/liqmap-levels": {
+      "get": {
+        "summary": "Fetch the multi-exchange liquidation map for one perp",
+        "description": "Full liquidation map snapshot for a Binance USDT-M perp: modeled leverage clusters, real forceOrder levels aggregated across Binance, Bybit, OKX, Gate, HTX and Hyperliquid, top magnets, funding, open interest and orderbook context.",
+        "operationId": "liqmap-levels",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/options-flow": {
+      "get": {
+        "summary": "Fetch Deribit options tape history and big prints",
+        "description": "BTC or ETH options tape depth from recorded Deribit flow: daily premium-flow history plus the full big-print list. The 24h summary alone is unmetered at /api/public/options-flow.",
+        "operationId": "options-flow",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.005000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    },
+    "/api/x402/flow-vpin": {
+      "get": {
+        "summary": "Fetch VPIN order-flow toxicity history for BTC, ETH, SOL",
+        "description": "Order flow toxicity (VPIN) history for BTC, ETH and SOL in one response: 90-day daily VPIN track with closes plus the last 500 volume buckets. The live snapshot alone is unmetered at /api/public/flow.",
+        "operationId": "flow-vpin",
+        "responses": {
+          "200": {
+            "description": "Requested data, returned after payment settles"
+          },
+          "402": {
+            "description": "Payment required: the response carries x402 payment requirements"
+          }
+        },
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.002000"
+          },
+          "networks": [
+            "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+            "eip155:8453"
+          ],
+          "asset": "USDC"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds one provider: `bykaranteli/derivatives` (category `finance`).

**Update (2026-09-18):** addresses the review note about missing query parameters and brings the provider in line with the live catalog.
- Every operation now declares the query parameters its handler honours: 21 of the 25 take `symbol`, `exchange`, `from`, `to`, `limit` or a route-specific filter (`metric`, `currency`, `timeframe`, `leverage`); the other four take none. They come from https://bykaranteli.com/openapi.json, which now publishes the same parameters.
- Four routes we delisted on our side (`dvol-history`, `slippage-history`, `premium-history`, `listings-history`, which now answer `410`) are removed, and sixteen live routes are added.
- The free `/api/x402` catalog is no longer in the sidecar, since the probe expects every listed operation to answer `402`; `PAY.md` still points to it.

ByKaranteli records crypto derivatives market structure continuously and sells depth and history per call over x402. 25 paid `GET` endpoints: 22 at $0.002 to $0.010 per call and three monthly bulk exports at $10 to $15, all answering `402` with an x402 v2 challenge. The endpoint table and the spend-aware notes are in `PAY.md`.

Payment is USDC on Solana mainnet (`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`) or Base mainnet, same amount either way, settled through the Coinbase CDP facilitator. No account, no signup and no API key for the paid routes; a failed response settles nothing.

### Checklist

- [x] `pay catalog check providers/bykaranteli/derivatives/PAY.md` green locally (`ghcr.io/solana-foundation/pay:latest`, pay 0.28.0, 2026-09-18): `PAY.md check successful`, `25 endpoints tested across 1 provider`, `25/25 gates compatible with Solana`. The registry-wide `catalog check . --no-probe` passes with no warning for this provider.
- [x] OpenAPI committed as a sidecar (`openapi: { path: openapi.json }`), pretty-printed.
- [x] `name:` matches the parent directory.
- [x] `description` 251 chars, `use_case` 237 chars.
- [x] No `TODO` placeholders; `service_url` is a production HTTPS domain.
- [x] Operation summaries start with a verb, are unique and fit the 63-char limit.

### One note on the sidecar

The committed `openapi.json` is generated from https://bykaranteli.com/openapi.json: the paid data operations with their query parameters and payment metadata, a short verb-first `summary` per operation, and the published summary moved into `description`. The prepaid credit route is left out because it sells credit, not data.
