### PR TITLE
Add SameDayDesk agent preflight APIs

### DIFF
--- a/providers/samedaydesk/opportunity-preflight/PAY.md
+++ b/providers/samedaydesk/opportunity-preflight/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: opportunity-preflight
-title: "SameDayDesk opportunity preflight on Solana"
-description: "Evaluate a bounty or paid work opportunity with deterministic break-even economics, acceptance gates, settlement checks, and reusable-value accounting."
-use_case: "Choose this before spending effort or money on a bounty, job, hackathon, or paid task. It turns supplied reward, cost, competition, access, acceptance, and settlement facts into attempt, verify_first, or abandon."
+title: "SameDayDesk agent preflight APIs on Solana"
+description: "Evaluate paid work economics or compare x402 and MPP payment offers before an agent authorizes effort or payment."
+use_case: "Choose work opportunity preflight before spending effort on a bounty or paid task. Choose payment offer preflight before authorizing one exact public HTTPS GET purchase."
 category: productivity
 service_url: https://solana.samedaydesk.com
 openapi:
@@ -10,8 +10,10 @@ openapi:
 ---
 
 Evaluate a bounty or paid work opportunity with deterministic break-even
-economics, acceptance gates, settlement checks, and reusable-value accounting.
-The service does not claim, bid, submit, or pay on source platforms.
+economics, acceptance gates, settlement checks, and reusable-value accounting,
+or inspect one target route's unpaid x402 and MPP challenges before buyer
+authorization. The service does not claim, bid, submit, authorize, sign, or pay
+on source platforms.
 
 ## Spend-aware usage
 
@@ -24,3 +26,5 @@ The service does not claim, bid, submit, or pay on source platforms.
   still rechecks the primary listing before acting.
 - Treat a missing selection probability as a deliberate `verify_first` result
   rather than paying for repeated guesses.
+- Use payment-offer preflight only with one complete public HTTPS GET URL. It
+  uses no target credential or target payment and reads no target response body.

--- a/providers/samedaydesk/opportunity-preflight/PAY.md
+++ b/providers/samedaydesk/opportunity-preflight/PAY.md
@@ -1,0 +1,26 @@
+---
+name: opportunity-preflight
+title: "SameDayDesk opportunity preflight on Solana"
+description: "Evaluate a bounty or paid work opportunity with deterministic break-even economics, acceptance gates, settlement checks, and reusable-value accounting."
+use_case: "Choose this before spending effort or money on a bounty, job, hackathon, or paid task. It turns supplied reward, cost, competition, access, acceptance, and settlement facts into attempt, verify_first, or abandon."
+category: productivity
+service_url: https://solana.samedaydesk.com
+openapi:
+  path: openapi.json
+---
+
+Evaluate a bounty or paid work opportunity with deterministic break-even
+economics, acceptance gates, settlement checks, and reusable-value accounting.
+The service does not claim, bid, submit, or pay on source platforms.
+
+## Spend-aware usage
+
+- Verify the live listing and collect every required input before calling so one
+  request produces the complete decision.
+- Reuse a result while reward, cost, competition, access, acceptance, and
+  settlement facts are unchanged. The output is deterministic for the same
+  normalized input.
+- Supply `platform` only when dated SameDayDesk evidence is useful. The caller
+  still rechecks the primary listing before acting.
+- Treat a missing selection probability as a deliberate `verify_first` result
+  rather than paying for repeated guesses.

--- a/providers/samedaydesk/opportunity-preflight/PAY.md
+++ b/providers/samedaydesk/opportunity-preflight/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: opportunity-preflight
 title: "SameDayDesk agent preflight APIs on Solana"
-description: "Evaluate paid work economics or compare x402 and MPP payment offers before an agent authorizes effort or payment."
-use_case: "Choose work opportunity preflight before spending effort on a bounty or paid task. Choose payment offer preflight before authorizing one exact public HTTPS GET purchase."
+description: "Evaluate paid work economics, compare x402 and MPP payment offers, or verify a finalized Solana SPL-token settlement."
+use_case: "Choose work opportunity preflight before spending effort on a bounty or paid task. Choose payment offer preflight before authorizing one exact public HTTPS GET purchase. Choose Solana transaction receipt after execution for finalized SPL-token evidence."
 category: productivity
 service_url: https://solana.samedaydesk.com
 openapi:
@@ -11,9 +11,10 @@ openapi:
 
 Evaluate a bounty or paid work opportunity with deterministic break-even
 economics, acceptance gates, settlement checks, and reusable-value accounting,
-or inspect one target route's unpaid x402 and MPP challenges before buyer
-authorization. The service does not claim, bid, submit, authorize, sign, or pay
-on source platforms.
+inspect one target route's unpaid x402 and MPP challenges before buyer
+authorization, or normalize and verify a finalized Solana transaction. The
+service does not claim, bid, submit, authorize, sign, broadcast, or pay on source
+platforms.
 
 ## Spend-aware usage
 
@@ -28,3 +29,6 @@ on source platforms.
   rather than paying for repeated guesses.
 - Use payment-offer preflight only with one complete public HTTPS GET URL. It
   uses no target credential or target payment and reads no target response body.
+- Use Solana transaction receipt with one finalized signature. Supply mint,
+  recipient, atomic amount, and payer only when exact settlement verification is
+  needed. The response excludes raw instructions and logs.

--- a/providers/samedaydesk/opportunity-preflight/openapi.json
+++ b/providers/samedaydesk/opportunity-preflight/openapi.json
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "SameDayDesk opportunity preflight on Solana",
+    "version": "1.0.0",
+    "description": "Deterministic opportunity economics and evidence gates. The service does not claim, bid, submit, or pay on source platforms."
+  },
+  "servers": [
+    {
+      "url": "https://solana.samedaydesk.com"
+    }
+  ],
+  "paths": {
+    "/work/opportunity-preflight": {
+      "get": {
+        "operationId": "opportunityPreflight",
+        "summary": "Evaluate a work opportunity before spending effort or money",
+        "description": "Returns deterministic break-even economics, hard blocks, required verification, warnings, and a bounded attempt, verify_first, or abandon decision.",
+        "parameters": [
+          {"name": "rewardUsd", "in": "query", "required": true, "schema": {"type": "number", "exclusiveMinimum": 0}, "description": "Gross reward in USD or USD-denominated stablecoin."},
+          {"name": "hours", "in": "query", "required": true, "schema": {"type": "number", "minimum": 0, "maximum": 10000}, "description": "Estimated execution hours."},
+          {"name": "hourlyCostUsd", "in": "query", "required": true, "schema": {"type": "number", "minimum": 0, "maximum": 100000}, "description": "Chosen opportunity cost per hour in USD."},
+          {"name": "computeUsd", "in": "query", "schema": {"type": "number", "minimum": 0}, "description": "Expected compute and API cost."},
+          {"name": "mandatorySpendUsd", "in": "query", "schema": {"type": "number", "minimum": 0}, "description": "Irrecoverable entry or execution spend."},
+          {"name": "reusableValueUsd", "in": "query", "schema": {"type": "number", "minimum": 0}, "description": "Conservative reusable value retained without selection."},
+          {"name": "selectionProbabilityPct", "in": "query", "schema": {"type": "number", "minimum": 0, "maximum": 100}, "description": "Caller-supplied probability estimate, not inferred by the service."},
+          {"name": "competition", "in": "query", "schema": {"type": "integer", "minimum": 0}, "description": "Visible competing entries or workers."},
+          {"name": "slots", "in": "query", "schema": {"type": "integer", "minimum": 1, "default": 1}, "description": "Number of paid or selected slots."},
+          {"name": "platform", "in": "query", "schema": {"type": "string"}, "description": "Optional platform identifier for dated SameDayDesk evidence."},
+          {"name": "agentAccess", "in": "query", "schema": {"type": "string", "enum": ["agent_allowed", "agent_only", "mixed", "human_only", "unknown"]}, "description": "Observed execution-access class."},
+          {"name": "acceptance", "in": "query", "schema": {"type": "string", "enum": ["deterministic", "machine_scored", "timed_review", "discretionary", "unknown"]}, "description": "Observed acceptance mechanism."},
+          {"name": "settlement", "in": "query", "schema": {"type": "string", "enum": ["direct", "escrow", "platform_balance", "discretionary", "unfunded", "unknown"]}, "description": "Observed settlement mechanism."}
+        ],
+        "responses": {
+          "200": {
+            "description": "Deterministic preflight result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["ok", "product", "version", "decision", "input", "economics", "gates", "boundary"],
+                  "properties": {
+                    "ok": {"type": "boolean"},
+                    "product": {"type": "string"},
+                    "version": {"type": "string"},
+                    "decision": {"type": "string", "enum": ["attempt", "verify_first", "abandon"]},
+                    "input": {"type": "object"},
+                    "economics": {"type": "object"},
+                    "gates": {"type": "object"},
+                    "platformEvidence": {"type": ["object", "null"]},
+                    "delivery": {"type": "object"},
+                    "boundary": {"type": "string"}
+                  }
+                }
+              }
+            }
+          },
+          "402": {"description": "Solana machine payment required"},
+          "503": {"description": "Input or delivery failure with no source-platform action"}
+        }
+      }
+    }
+  }
+}

--- a/providers/samedaydesk/opportunity-preflight/openapi.json
+++ b/providers/samedaydesk/opportunity-preflight/openapi.json
@@ -2,13 +2,13 @@
   "openapi": "3.1.0",
   "info": {
     "title": "SameDayDesk agent preflight APIs on Solana",
-    "version": "1.1.0",
-    "description": "Deterministic opportunity economics plus credential-free x402 and MPP offer inspection. The service does not claim, bid, submit, authorize, sign, or pay on source platforms.",
+    "version": "1.2.0",
+    "description": "Deterministic opportunity economics, credential-free x402 and MPP offer inspection, and finalized Solana transaction evidence. The service does not claim, bid, submit, authorize, sign, broadcast, or pay on source platforms.",
     "contact": {
       "email": "contact@samedaydesk.com",
       "url": "https://samedaydesk.com"
     },
-    "x-guidance": "Use /work/opportunity-preflight for bounty and paid-task economics. Use /commerce/payment-offer-preflight to inspect one exact public HTTPS GET route before authorizing its payment. Supply every required query parameter, inspect this server's live HTTP 402 x402 and MPP offers, enforce your own Solana-USDC price policy, then retry the identical request with one supported payment credential."
+    "x-guidance": "Use /work/opportunity-preflight for bounty and paid-task economics. Use /commerce/payment-offer-preflight to inspect one exact public HTTPS GET route before authorizing its payment. Use /chain/solana-transaction-receipt after execution to normalize a finalized transaction and optionally verify an exact SPL-token settlement claim. Supply every required query parameter, inspect this server's live HTTP 402 x402 and MPP offers, enforce your own Solana-USDC price policy, then retry the identical request with one supported payment credential."
   },
   "servers": [
     {
@@ -19,7 +19,7 @@
     "/work/opportunity-preflight": {
       "get": {
         "operationId": "opportunityPreflight",
-        "summary": "Evaluate a work opportunity before spending effort or money",
+        "summary": "Validate work opportunity economics before spending",
         "description": "Returns deterministic break-even economics, hard blocks, required verification, warnings, and a bounded attempt, verify_first, or abandon decision.",
         "tags": ["Agent Operations"],
         "x-payment-info": {
@@ -163,6 +163,55 @@
           },
           "402": {"description": "Solana machine payment required"},
           "502": {"description": "Target DNS, transport, redirect, or challenge failure after payment"}
+        }
+      }
+    },
+    "/chain/solana-transaction-receipt": {
+      "get": {
+        "operationId": "solanaTransactionReceipt",
+        "summary": "Fetch and verify a finalized Solana transaction receipt",
+        "description": "Returns finalized status, slot, block time, fee, SPL-token owner deltas, canonical USDC deltas, and optional exact mint, recipient, amount, and payer verification. Uses bounded public Solana RPCs and returns no raw instructions or logs.",
+        "tags": ["Blockchain"],
+        "x-payment-info": {
+          "price": {"amount": "0.002", "currency": "USD", "mode": "fixed"},
+          "protocols": [
+            {"x402": {"asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp", "scheme": "exact"}},
+            {"mpp": {"currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", "intent": "charge", "method": "solana", "network": "mainnet"}}
+          ]
+        },
+        "parameters": [
+          {"name": "signature", "in": "query", "required": true, "description": "Finalized Solana mainnet transaction signature.", "schema": {"type": "string", "pattern": "^[1-9A-HJ-NP-Za-km-z]{80,90}$"}},
+          {"name": "mint", "in": "query", "required": false, "description": "SPL-token mint to verify. Defaults to canonical Solana USDC.", "schema": {"type": "string", "pattern": "^[1-9A-HJ-NP-Za-km-z]{32,44}$", "default": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}},
+          {"name": "recipient", "in": "query", "required": false, "description": "Optional expected token recipient owner.", "schema": {"type": "string", "pattern": "^[1-9A-HJ-NP-Za-km-z]{32,44}$"}},
+          {"name": "amountAtomic", "in": "query", "required": false, "description": "Optional expected positive token amount in atomic units; requires recipient.", "schema": {"type": "string", "pattern": "^[1-9][0-9]{0,19}$"}},
+          {"name": "payer", "in": "query", "required": false, "description": "Optional expected token payer owner; requires recipient and amountAtomic.", "schema": {"type": "string", "pattern": "^[1-9A-HJ-NP-Za-km-z]{32,44}$"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized finalized Solana receipt and optional exact SPL-token settlement verification",
+            "content": {"application/json": {"schema": {
+              "type": "object",
+              "required": ["ok", "product", "version", "checkedAt", "decision", "request", "chain", "transaction", "receipt", "tokenOwnerDeltas", "canonicalUsdcOwnerDeltas", "verification", "findings", "boundary"],
+              "properties": {
+                "ok": {"type": "boolean"},
+                "product": {"type": "string", "const": "samedaydesk-solana-transaction-receipt"},
+                "version": {"type": "string"},
+                "checkedAt": {"type": "string"},
+                "decision": {"type": "string", "enum": ["found", "verified", "not_verified", "not_found", "rpc_unavailable"]},
+                "request": {"type": "object"},
+                "chain": {"type": "object"},
+                "transaction": {"type": "object"},
+                "receipt": {"type": "object"},
+                "tokenOwnerDeltas": {"type": "array"},
+                "canonicalUsdcOwnerDeltas": {"type": "array"},
+                "verification": {"type": "object"},
+                "findings": {"type": "array"},
+                "boundary": {"type": "object"},
+                "delivery": {"type": "object"}
+              }
+            }}}
+          },
+          "402": {"description": "Solana machine payment required"}
         }
       }
     }

--- a/providers/samedaydesk/opportunity-preflight/openapi.json
+++ b/providers/samedaydesk/opportunity-preflight/openapi.json
@@ -3,7 +3,12 @@
   "info": {
     "title": "SameDayDesk opportunity preflight on Solana",
     "version": "1.0.0",
-    "description": "Deterministic opportunity economics and evidence gates. The service does not claim, bid, submit, or pay on source platforms."
+    "description": "Deterministic opportunity economics and evidence gates. The service does not claim, bid, submit, or pay on source platforms.",
+    "contact": {
+      "email": "contact@samedaydesk.com",
+      "url": "https://samedaydesk.com"
+    },
+    "x-guidance": "Collect the complete reward, cost, competition, access, acceptance, and settlement facts before one call. Inspect the live HTTP 402 x402 and MPP offers, enforce your own Solana-USDC price policy, then retry the identical method, path, and query with one supported payment credential. Reuse the deterministic result while inputs remain unchanged."
   },
   "servers": [
     {
@@ -16,6 +21,31 @@
         "operationId": "opportunityPreflight",
         "summary": "Evaluate a work opportunity before spending effort or money",
         "description": "Returns deterministic break-even economics, hard blocks, required verification, warnings, and a bounded attempt, verify_first, or abandon decision.",
+        "tags": ["Agent Operations"],
+        "x-payment-info": {
+          "price": {
+            "amount": "0.01",
+            "currency": "USD",
+            "mode": "fixed"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "scheme": "exact"
+              }
+            },
+            {
+              "mpp": {
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "intent": "charge",
+                "method": "solana",
+                "network": "mainnet"
+              }
+            }
+          ]
+        },
         "parameters": [
           {"name": "rewardUsd", "in": "query", "required": true, "schema": {"type": "number", "exclusiveMinimum": 0}, "description": "Gross reward in USD or USD-denominated stablecoin."},
           {"name": "hours", "in": "query", "required": true, "schema": {"type": "number", "minimum": 0, "maximum": 10000}, "description": "Estimated execution hours."},

--- a/providers/samedaydesk/opportunity-preflight/openapi.json
+++ b/providers/samedaydesk/opportunity-preflight/openapi.json
@@ -1,14 +1,14 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "SameDayDesk opportunity preflight on Solana",
-    "version": "1.0.0",
-    "description": "Deterministic opportunity economics and evidence gates. The service does not claim, bid, submit, or pay on source platforms.",
+    "title": "SameDayDesk agent preflight APIs on Solana",
+    "version": "1.1.0",
+    "description": "Deterministic opportunity economics plus credential-free x402 and MPP offer inspection. The service does not claim, bid, submit, authorize, sign, or pay on source platforms.",
     "contact": {
       "email": "contact@samedaydesk.com",
       "url": "https://samedaydesk.com"
     },
-    "x-guidance": "Collect the complete reward, cost, competition, access, acceptance, and settlement facts before one call. Inspect the live HTTP 402 x402 and MPP offers, enforce your own Solana-USDC price policy, then retry the identical method, path, and query with one supported payment credential. Reuse the deterministic result while inputs remain unchanged."
+    "x-guidance": "Use /work/opportunity-preflight for bounty and paid-task economics. Use /commerce/payment-offer-preflight to inspect one exact public HTTPS GET route before authorizing its payment. Supply every required query parameter, inspect this server's live HTTP 402 x402 and MPP offers, enforce your own Solana-USDC price policy, then retry the identical request with one supported payment credential."
   },
   "servers": [
     {
@@ -87,6 +87,82 @@
           },
           "402": {"description": "Solana machine payment required"},
           "503": {"description": "Input or delivery failure with no source-platform action"}
+        }
+      }
+    },
+    "/commerce/payment-offer-preflight": {
+      "get": {
+        "operationId": "paymentOfferPreflight",
+        "summary": "Compare x402 and MPP offers before authorizing payment",
+        "description": "Inspects the unpaid challenge headers of one exact public HTTPS GET route, normalizes x402 and MPP terms, checks route and realm binding, expiry, and economic parity, then returns a bounded authorization decision. Uses no target credential, signs nothing, sends no target payment, follows no redirect, and reads no target response body.",
+        "tags": ["Agent Operations"],
+        "x-payment-info": {
+          "price": {
+            "amount": "0.005",
+            "currency": "USD",
+            "mode": "fixed"
+          },
+          "protocols": [
+            {
+              "x402": {
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                "scheme": "exact"
+              }
+            },
+            {
+              "mpp": {
+                "currency": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                "intent": "charge",
+                "method": "solana",
+                "network": "mainnet"
+              }
+            }
+          ]
+        },
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "description": "Exact public HTTPS GET route whose unpaid x402 and MPP challenge headers should be inspected. Credential-like query keys, fragments, unresolved parameters, local hosts, redirects, and non-public IPs are rejected.",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "maxLength": 2048,
+              "example": "https://agents.samedaydesk.com/defi/morpho-position?address=0x8ee9c15c3e5332cbc6ef39a2bb036c63c6549b6e"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized x402 and MPP offers, binding checks, economic parity, and a bounded decision",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["ok", "product", "version", "checkedAt", "target", "decision", "protocols", "offerCount", "offers", "parity", "findings", "boundary"],
+                  "properties": {
+                    "ok": {"type": "boolean"},
+                    "product": {"type": "string", "const": "samedaydesk-payment-offer-preflight"},
+                    "version": {"type": "string"},
+                    "checkedAt": {"type": "string"},
+                    "target": {"type": "object"},
+                    "decision": {"type": "string", "enum": ["parseable_offer", "review_required", "no_parseable_offer"]},
+                    "protocols": {"type": "array", "items": {"type": "string", "enum": ["mpp", "x402"]}},
+                    "offerCount": {"type": "integer", "minimum": 0},
+                    "offers": {"type": "array"},
+                    "parity": {"type": "object"},
+                    "findings": {"type": "array"},
+                    "boundary": {"type": "object"},
+                    "delivery": {"type": "object"}
+                  }
+                }
+              }
+            }
+          },
+          "402": {"description": "Solana machine payment required"},
+          "502": {"description": "Target DNS, transport, redirect, or challenge failure after payment"}
         }
       }
     }


### PR DESCRIPTION
## Summary

Adds `samedaydesk/opportunity-preflight`, a dual-product Solana provider for agent decisions before effort or payment:

- `GET /work/opportunity-preflight` evaluates paid-work economics at 0.01 USDC
- `GET /commerce/payment-offer-preflight` compares one public route's x402 and MPP offers at 0.005 USDC

Both operations publish complete invocation and output contracts. The service does not claim, bid, submit, authorize, sign, or pay on source platforms.

## Validation

- `pay catalog check . --changed-from upstream/main --format json --probe-timeout 15`
- One provider and two endpoints detected
- Both live probes: `ok`
- Both Solana verdicts: `ok`
- Both challenges classified as paid via MPP
- Production challenges also advertise x402 exact

A bounded owner QA canary previously paid exactly 0.01 USDC from a separate buyer to the dedicated merchant and received the work-preflight response. Finalized transaction: https://solscan.io/tx/3CjY38avdggKZbKfu2BmFYN4MUTiiNX27c8dHzPW79PrAx3huB9Pa6AfwW6sT4biax3y22z8toyLzmjtCc2QGNZn

That transaction is owner QA and reproducible settlement evidence, not a claim of independent demand or revenue. The added payment-offer route reused the already-proven payment and delivery path, so no second owner payment was sent.
