### PR TITLE
feat: add Phoenix Zero — Silicon DNA (behavioral bot/agent classifier, security)

### DIFF
--- a/providers/phoenix-zero/silicon-dna/PAY.md
+++ b/providers/phoenix-zero/silicon-dna/PAY.md
@@ -1,0 +1,30 @@
+---
+name: silicon-dna
+title: "Phoenix Zero — Silicon DNA"
+description: "Behavioral bot/agent classifier. POST session timing signals, get HUMAN / LEGIT_AGENT / MALICIOUS_BOT with confidence, via x402 micropayments. Tells a legitimate high-frequency trading agent apart from a spam script at the gateway."
+use_case: "Use as an abuse/fraud pre-check before granting an agent access to a paid or rate-limited resource: RPC gateways, airdrop claims, governance actions, or any endpoint that must tell a real agent from a bot farm. Complements IP allow/deny lists with behavioral signals."
+category: security
+service_url: https://rtt.phoenix-ai.work
+openapi:
+  path: openapi.json
+---
+
+Silicon DNA is a full-time behavioral bot-detection system. This skill exposes its
+3-class agent classifier as a paid x402 endpoint.
+
+## Endpoint
+
+- `POST /api/v1/classify` — send behavioral session signals (entropy, timing variance,
+  autocorrelation, Spearman rho, request intervals, optional IP). Returns
+  `{"agentClass": "HUMAN|LEGIT_AGENT|MALICIOUS_BOT", "confidence": 0..1, "signals": [...]}`.
+
+## What it detects
+
+Scripted/zero-variance timing (spam bots), low-entropy sessions, static-script patterns
+(Spearman correlation), and inconsistent fingerprints — combined into one verdict, with the
+contributing signals returned for auditability. The decision is interpretable threshold
+logic over the submitted signals, not a black-box model.
+
+## Payment
+
+x402 USDC on Base (eip155:8453), $0.01 per call.

--- a/providers/phoenix-zero/silicon-dna/openapi.json
+++ b/providers/phoenix-zero/silicon-dna/openapi.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Phoenix Zero — Silicon DNA Agent Identity",
+    "version": "1.0.0",
+    "description": "Behavioral bot/agent classification. Returns HUMAN / LEGIT_AGENT / MALICIOUS_BOT from session timing signals, with confidence and the contributing signals."
+  },
+  "servers": [{"url": "https://rtt.phoenix-ai.work/api"}],
+  "paths": {
+    "/v1/classify": {
+      "post": {
+        "summary": "Classify a caller as HUMAN / LEGIT_AGENT / MALICIOUS_BOT",
+        "description": "Silicon DNA behavioral classifier. Takes optional session timing/entropy signals and returns a 3-class agent verdict with confidence and the contributing signals. x402-paid ($0.01 USDC on Base).",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Behavioral session signals; all optional, more signals raise confidence.",
+                "properties": {
+                  "ip": {"type": "string", "description": "Caller IP; correlated against the ban list."},
+                  "entropy": {"type": "number", "description": "Inter-event entropy of the session."},
+                  "variance": {"type": "number", "description": "Timing variance; near-zero indicates scripted traffic."},
+                  "autocorr": {"type": "number", "description": "Autocorrelation of request intervals."},
+                  "spearmanRho": {"type": "number", "description": "Spearman rho for static-script detection."},
+                  "requestIntervals": {"type": "array", "items": {"type": "number"}, "description": "Millisecond gaps between requests."}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Classification result with confidence and contributing signals.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "agentClass": {"type": "string", "enum": ["HUMAN", "LEGIT_AGENT", "MALICIOUS_BOT"], "description": "Three-class verdict."},
+                    "confidence": {"type": "number", "description": "Confidence 0..1."},
+                    "signals": {"type": "array", "items": {"type": "string"}, "description": "Human-readable contributing signals."}
+                  }
+                }
+              }
+            }
+          },
+          "402": {"description": "Payment required (x402): pay $0.01 USDC on Base and retry."}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a second Phoenix Zero provider under the **security** category: an x402-paid behavioral bot/agent classifier.

- `POST /api/v1/classify` → `{agentClass: HUMAN|LEGIT_AGENT|MALICIOUS_BOT, confidence, signals}` from session timing signals (entropy, variance, autocorrelation, Spearman rho, request intervals).
- Committed `openapi.json` (3.1.0) per the current catalog rules; live endpoint returns a real x402 402 challenge ($0.01 USDC on Base).
- Use case: abuse/fraud pre-check at RPC gateways, airdrop claims, governance — telling a legit high-frequency agent from a spam script.

Companion to #73 (sequencer-health). Interpretable threshold logic, not a black-box model.