### PR TITLE
feat(catalog): add general-relay/maritime

### DIFF
--- a/providers/general-relay/maritime/PAY.md
+++ b/providers/general-relay/maritime/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: maritime
 title: General Relay Maritime
-description: "Latest AIS vessel positions by MMSI from a network of terrestrial VHF receivers: latitude, longitude, speed and course over ground, heading, navigational status, fix age, plus ship name, call sign, IMO number and hull dimensions."
-use_case: "Use for finding where a ship is by MMSI, vessel and maritime traffic lookups, port and coastal vessel presence, and resolving a hull's name, call sign or IMO number. You are charged only when a position is found, so a miss costs nothing."
+description: "Latest AIS vessel positions by MMSI from terrestrial VHF receivers, enriched with FCC ship-station licences, USCG hull records, EU MRV emissions and deadweight, water body names, chokepoint sea conditions and active NAVAREA warnings."
+use_case: "Use for finding where a ship is by MMSI, vessel registry and ownership lookups, ship emissions and deadweight, sea state near chokepoints, navigational warnings, and resolving a hull's name, call sign or IMO. Charged only when a position is found."
 category: data
 version: v1
 service_url: https://api.generalrelay.xyz
@@ -10,10 +10,13 @@ openapi:
   path: openapi.json
 ---
 
-`GET /v1/vessel?mmsi=` — latest AIS position for one vessel, $0.005 per hit in
-USDC on Solana mainnet. **You are charged only when a position is found**: a
-400, 404 or 503 settles nothing. The operator sponsors the transaction fee, so a
-caller needs USDC and nothing else.
+`GET /v1/vessel?mmsi=` — latest AIS position for one vessel plus everything on
+file for the hull: FCC licence and USCG record for US vessels, EU MRV verified
+emissions and deadweight, the named water body, sea conditions at the nearest
+monitored chokepoint within 200 km, and active NAVAREA warnings for the region.
+$0.005 per hit in USDC on Solana mainnet. **You are charged only when a
+position is found**: a 400, 404 or 503 settles nothing. The operator sponsors
+the transaction fee, so a caller needs USDC and nothing else.
 
 ## Spend-aware usage
 
@@ -24,3 +27,11 @@ caller needs USDC and nothing else.
   list.
 - Check `position.age_seconds` before trusting a fix: during an ingest outage the
   last known position keeps being served.
+- Enrichment sections (`registry`, `emissions`, `water_body`,
+  `nearest_chokepoint`, `navigational_warnings`) are null when nothing is on
+  file for that hull or place; the price is the same either way, so treat them
+  as upside rather than something to retry for.
+- `navigational_warnings: null` means the warning feed could not be checked;
+  `"active": 0` means it was checked and nothing is in force. Only the second
+  is a claim. The list is area-level (NAVAREA/HYDRO broadcast areas), not
+  vessel proximity.

--- a/providers/general-relay/maritime/PAY.md
+++ b/providers/general-relay/maritime/PAY.md
@@ -15,7 +15,7 @@ file for the hull: FCC licence and USCG record for US vessels, EU MRV verified
 emissions and deadweight, the named water body, sea conditions at the nearest
 monitored chokepoint within 200 km, and active NAVAREA warnings for the region.
 $0.005 per hit in USDC on Solana mainnet. **You are charged only when a
-position is found**: a 400, 404 or 503 settles nothing. The operator sponsors
+position is found**: a 400, 404, 500 or 503 settles nothing. The operator sponsors
 the transaction fee, so a caller needs USDC and nothing else.
 
 ## Spend-aware usage

--- a/providers/general-relay/maritime/PAY.md
+++ b/providers/general-relay/maritime/PAY.md
@@ -1,0 +1,26 @@
+---
+name: maritime
+title: General Relay Maritime
+description: "Latest AIS vessel positions by MMSI from a network of terrestrial VHF receivers: latitude, longitude, speed and course over ground, heading, navigational status, fix age, plus ship name, call sign, IMO number and hull dimensions."
+use_case: "Use for finding where a ship is by MMSI, vessel and maritime traffic lookups, port and coastal vessel presence, and resolving a hull's name, call sign or IMO number. You are charged only when a position is found, so a miss costs nothing."
+category: data
+version: v1
+service_url: https://api.generalrelay.xyz
+openapi:
+  path: openapi.json
+---
+
+`GET /v1/vessel?mmsi=` — latest AIS position for one vessel, $0.005 per hit in
+USDC on Solana mainnet. **You are charged only when a position is found**: a
+400, 404 or 503 settles nothing. The operator sponsors the transaction fee, so a
+caller needs USDC and nothing else.
+
+## Spend-aware usage
+
+- `mmsi` is exactly nine decimal digits and leading zeros are significant, so
+  never round-trip one through an integer — `002442000` is not `2442000`.
+- Misses cost nothing, but a 404 still reports `vessels`, the number of distinct
+  MMSIs heard in the last hour. Zero means back off rather than work through a
+  list.
+- Check `position.age_seconds` before trusting a fix: during an ingest outage the
+  last known position keeps being served.

--- a/providers/general-relay/maritime/PAY.md
+++ b/providers/general-relay/maritime/PAY.md
@@ -1,8 +1,8 @@
 ---
 name: maritime
 title: General Relay Maritime
-description: "Latest AIS vessel positions by MMSI from terrestrial VHF receivers, enriched with FCC ship-station licences, USCG hull records, EU MRV emissions and deadweight, water body names, chokepoint sea conditions and active NAVAREA warnings."
-use_case: "Use for finding where a ship is by MMSI, vessel registry and ownership lookups, ship emissions and deadweight, sea state near chokepoints, navigational warnings, and resolving a hull's name, call sign or IMO. Charged only when a position is found."
+description: "AIS vessel search by name, IMO, MMSI, bounding box or radius. Returns latest positions from terrestrial VHF and AISHub, not global coverage. Name and IMO can be null. Charged $0.02 per non-empty result."
+use_case: "Use for finding ships by name, IMO or MMSI, searching a 5° bbox or 500 km radius, coastal AIS positions, and vessel identity lookups. Empty results, 400, 500 and 503 settle nothing."
 category: data
 version: v1
 service_url: https://api.generalrelay.xyz
@@ -10,28 +10,29 @@ openapi:
   path: openapi.json
 ---
 
-`GET /v1/vessel?mmsi=` — latest AIS position for one vessel plus everything on
-file for the hull: FCC licence and USCG record for US vessels, EU MRV verified
-emissions and deadweight, the named water body, sea conditions at the nearest
-monitored chokepoint within 200 km, and active NAVAREA warnings for the region.
-$0.005 per hit in USDC on Solana mainnet. **You are charged only when a
-position is found**: a 400, 404, 500 or 503 settles nothing. The operator sponsors
-the transaction fee, so a caller needs USDC and nothing else.
+`GET /v1/vessels` — Search vessels by identity, location, or both. Charged
+per non-empty result: empty array, 400, 500, 503 settle nothing. $0.02 per
+non-empty result in USDC on Solana mainnet (`exact`). The operator sponsors
+the transaction fee, so a caller needs USDC and nothing else. Coverage is
+terrestrial VHF + AISHub, not global. Name and IMO can be null.
+
+All filters are optional, but at least one is required. Identity filters
+(`name` substring, `imo` exact, `mmsi` exact 9-digit string) AND together.
+Spatial is one mode: bbox (`lat_min`/`lat_max`/`lon_min`/`lon_max`, max 5°×5°)
+XOR radius (`lat`/`lon`/`radius_km`, max 500 km).
 
 ## Spend-aware usage
 
-- `mmsi` is exactly nine decimal digits and leading zeros are significant, so
-  never round-trip one through an integer — `002442000` is not `2442000`.
-- Misses cost nothing, but a 404 still reports `vessels`, the number of distinct
-  MMSIs heard in the last hour. Zero means back off rather than work through a
-  list.
-- Check `position.age_seconds` before trusting a fix: during an ingest outage the
-  last known position keeps being served.
-- Enrichment sections (`registry`, `emissions`, `water_body`,
-  `nearest_chokepoint`, `navigational_warnings`) are null when nothing is on
-  file for that hull or place; the price is the same either way, so treat them
-  as upside rather than something to retry for.
-- `navigational_warnings: null` means the warning feed could not be checked;
-  `"active": 0` means it was checked and nothing is in force. Only the second
-  is a claim. The list is area-level (NAVAREA/HYDRO broadcast areas), not
-  vessel proximity.
+- An empty call (no filters) is 400 and settles nothing — pick identity,
+  bbox, or radius before paying.
+- Identity filters AND: `name=PACIFIC&mmsi=232004521` must satisfy both.
+- Do not send bbox and radius together; that is 400.
+- `mmsi` is exactly nine decimal digits and leading zeros are significant,
+  so never round-trip one through an integer — `002442000` is not `2442000`.
+- Empty arrays cost nothing. Prefer a tight bbox or radius over a broad
+  coastal sweep; results are capped at 100, ordered by `last_seen` DESC.
+- Check `position.age_seconds` before trusting a fix: during an ingest
+  outage the last known position keeps being served.
+- Name and IMO can be null on a hit. Enrichment sections (`registry`,
+  `emissions`, `water_body`, `nearest_chokepoint`, `navigational_warnings`)
+  are also null when nothing is on file; the price is the same either way.

--- a/providers/general-relay/maritime/openapi.json
+++ b/providers/general-relay/maritime/openapi.json
@@ -1,5 +1,9 @@
 {
   "info": {
+    "contact": {
+      "email": "jackdrieck@gmail.com"
+    },
+    "description": "Real-time maritime data, paid per call. Ask for a vessel by MMSI and get its position and metadata.",
     "title": "General Relay",
     "version": "v1"
   },
@@ -7,7 +11,7 @@
   "paths": {
     "/v1/vessel": {
       "get": {
-        "description": "Latest AIS position for one vessel by MMSI (?mmsi=, exactly nine decimal digits): latitude, longitude, speed, course, heading, report time, age_seconds, plus name, call sign, IMO and dimensions once a static report is seen. Coverage is a network of terrestrial VHF receivers, so vessels far from any receiver and most of the open ocean will miss. Latest position only, no history. You are charged only when a position is found: a miss settles nothing.",
+        "description": "Latest AIS position for one vessel by MMSI (?mmsi=, nine decimal digits), plus everything on file for the hull: FCC licence and USCG record for US vessels, EU MRV verified emissions, the named water body, sea conditions at the nearest monitored chokepoint within 200 km, and active NAVAREA warnings for the region. Sections are null when nothing is on file. Coverage is terrestrial VHF receivers — most of the open ocean will miss. Charged only when a position is found: a miss settles nothing.",
         "parameters": [
           {
             "description": "The vessel's MMSI, exactly nine decimal digits, e.g. 366123456. Sent as text and never as a number: leading zeros are significant (009-prefixed identifiers are coast stations), so 002442000 and 2442000 are not the same vessel.",
@@ -33,11 +37,61 @@
                     "starboard": 16,
                     "stern": 28
                   },
+                  "emissions": {
+                    "dwt": 63400.0,
+                    "gross_tonnage": 52450.0,
+                    "reporting_year": 2024,
+                    "ship_type": "Container ship",
+                    "technical_efficiency": "EIV (18.42 gCO₂/t·nm)",
+                    "total_co2_emissions_t": 55471.3,
+                    "total_fuel_consumption_t": 17820.5
+                  },
                   "first_seen": "2026-06-02T09:14:03Z",
                   "imo_number": 9394521,
                   "last_seen": "2026-08-10T14:03:53Z",
                   "mmsi": "232004521",
                   "name": "PACIFIC ENDEAVOUR",
+                  "navigational_warnings": {
+                    "active": 7,
+                    "areas": [
+                      "4",
+                      "HYDROLANT"
+                    ],
+                    "items": [
+                      {
+                        "excerpt": "ENGLISH CHANNEL. DOVER STRAIT. DERELICT VESSEL ADRIFT IN 51-02N 001-28E AT 081600Z UTC...",
+                        "issue_date": "081653Z AUG 2026",
+                        "msg_number": 812,
+                        "msg_year": 2026,
+                        "nav_area": "HYDROLANT",
+                        "subregion": "24"
+                      }
+                    ],
+                    "scope": "the NAVAREA/HYDRO broadcast areas covering this position, not vessel proximity"
+                  },
+                  "nearest_chokepoint": {
+                    "distance_km": 74.51,
+                    "name": "Strait of Dover",
+                    "sea_state": {
+                      "time": "2026-08-10T12:00:00Z",
+                      "wave_direction_deg": 215,
+                      "wave_height_m": 1.31,
+                      "wave_period_s": 5.9
+                    },
+                    "weather": {
+                      "pressure_hpa": 1013.4,
+                      "sea_surface_temp_c": 17.2,
+                      "swell_wave_height_m": 0.8,
+                      "time": "2026-08-10T14:00:00Z",
+                      "visibility_m": 18000.0,
+                      "wave_direction_deg": 210,
+                      "wave_height_m": 1.24,
+                      "wave_period_s": 5.6,
+                      "wind_direction_deg": 225,
+                      "wind_gusts_kmh": 41.0,
+                      "wind_speed_kmh": 28.4
+                    }
+                  },
                   "position": {
                     "age_seconds": 12,
                     "course_over_ground": 94.2,
@@ -49,7 +103,497 @@
                     "speed_over_ground": 11.4,
                     "time": "2026-08-10T14:03:53Z"
                   },
-                  "ship_type": 70
+                  "registry": null,
+                  "ship_type": 70,
+                  "water_body": {
+                    "mrgid": 4374,
+                    "name": "Thames Estuary",
+                    "note": "a name from a bounding-box gazetteer, for orientation only — not a jurisdictional or navigational claim",
+                    "place_type": "Estuary"
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "call_sign": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "dimensions": {
+                      "properties": {
+                        "beam": {
+                          "type": "integer"
+                        },
+                        "bow": {
+                          "type": "integer"
+                        },
+                        "length": {
+                          "type": "integer"
+                        },
+                        "port": {
+                          "type": "integer"
+                        },
+                        "starboard": {
+                          "type": "integer"
+                        },
+                        "stern": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "bow",
+                        "stern",
+                        "port",
+                        "starboard",
+                        "length",
+                        "beam"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "emissions": {
+                      "properties": {
+                        "dwt": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "gross_tonnage": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "reporting_year": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "ship_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "technical_efficiency": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "total_co2_emissions_t": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "total_fuel_consumption_t": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "reporting_year",
+                        "ship_type",
+                        "dwt",
+                        "gross_tonnage",
+                        "total_fuel_consumption_t",
+                        "total_co2_emissions_t",
+                        "technical_efficiency"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "first_seen": {
+                      "format": "date-time",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "imo_number": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "last_seen": {
+                      "format": "date-time",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "mmsi": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "navigational_warnings": {
+                      "properties": {
+                        "active": {
+                          "type": "integer"
+                        },
+                        "areas": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "items": {
+                          "items": {
+                            "properties": {
+                              "excerpt": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "issue_date": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              },
+                              "msg_number": {
+                                "type": "integer"
+                              },
+                              "msg_year": {
+                                "type": "integer"
+                              },
+                              "nav_area": {
+                                "type": "string"
+                              },
+                              "subregion": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "nav_area",
+                              "msg_year",
+                              "msg_number",
+                              "subregion",
+                              "issue_date",
+                              "excerpt"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "scope": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "scope",
+                        "areas",
+                        "active",
+                        "items"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "nearest_chokepoint": {
+                      "properties": {
+                        "distance_km": {
+                          "type": "number"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "sea_state": {
+                          "properties": {
+                            "time": {
+                              "format": "date-time",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "wave_direction_deg": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "wave_height_m": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "wave_period_s": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "time",
+                            "wave_height_m",
+                            "wave_direction_deg",
+                            "wave_period_s"
+                          ],
+                          "type": [
+                            "object",
+                            "null"
+                          ]
+                        },
+                        "weather": {
+                          "properties": {
+                            "pressure_hpa": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "sea_surface_temp_c": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "swell_wave_height_m": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "time": {
+                              "format": "date-time",
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "visibility_m": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "wave_direction_deg": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "wave_height_m": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "wave_period_s": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "wind_direction_deg": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "wind_gusts_kmh": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            },
+                            "wind_speed_kmh": {
+                              "type": [
+                                "number",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "time",
+                            "wave_height_m",
+                            "wave_direction_deg",
+                            "wave_period_s",
+                            "swell_wave_height_m",
+                            "wind_speed_kmh",
+                            "wind_gusts_kmh",
+                            "wind_direction_deg",
+                            "visibility_m",
+                            "sea_surface_temp_c",
+                            "pressure_hpa"
+                          ],
+                          "type": [
+                            "object",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "distance_km",
+                        "weather",
+                        "sea_state"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "position": {
+                      "properties": {
+                        "age_seconds": {
+                          "type": "integer"
+                        },
+                        "course_over_ground": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "heading": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "latitude": {
+                          "type": "number"
+                        },
+                        "longitude": {
+                          "type": "number"
+                        },
+                        "msg_type": {
+                          "type": "integer"
+                        },
+                        "nav_status": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "speed_over_ground": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "time": {
+                          "format": "date-time",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "latitude",
+                        "longitude",
+                        "time",
+                        "age_seconds",
+                        "speed_over_ground",
+                        "course_over_ground",
+                        "heading",
+                        "nav_status",
+                        "msg_type"
+                      ],
+                      "type": "object"
+                    },
+                    "registry": {
+                      "properties": {
+                        "fcc": {
+                          "type": [
+                            "object",
+                            "null"
+                          ]
+                        },
+                        "uscg": {
+                          "type": [
+                            "object",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "fcc",
+                        "uscg"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    },
+                    "ship_type": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "water_body": {
+                      "properties": {
+                        "mrgid": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "note": {
+                          "type": "string"
+                        },
+                        "place_type": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "place_type",
+                        "mrgid",
+                        "note"
+                      ],
+                      "type": [
+                        "object",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "mmsi",
+                    "name",
+                    "call_sign",
+                    "imo_number",
+                    "ship_type",
+                    "dimensions",
+                    "position",
+                    "first_seen",
+                    "last_seen",
+                    "registry",
+                    "emissions",
+                    "water_body",
+                    "nearest_chokepoint",
+                    "navigational_warnings"
+                  ],
+                  "type": "object"
                 }
               }
             },
@@ -59,7 +603,7 @@
             "description": "Payment Required"
           }
         },
-        "summary": "Get the latest AIS position for one vessel by MMSI",
+        "summary": "Get one vessel's position, registry and local conditions",
         "x-payment-info": {
           "offers": [
             {
@@ -82,5 +626,12 @@
     {
       "url": "https://api.generalrelay.xyz"
     }
-  ]
+  ],
+  "x-service-info": {
+    "docs": {
+      "apiReference": "https://api.generalrelay.xyz/.well-known/openapi.json",
+      "homepage": "https://generalrelay.xyz",
+      "llms": "https://api.generalrelay.xyz/llms.txt"
+    }
+  }
 }

--- a/providers/general-relay/maritime/openapi.json
+++ b/providers/general-relay/maritime/openapi.json
@@ -3,21 +3,44 @@
     "contact": {
       "email": "jackdrieck@gmail.com"
     },
-    "description": "Real-time maritime data, paid per call. Ask for a vessel by MMSI and get its position and metadata.",
+    "description": "Search vessels by identity, location, or both. Charged per non-empty result: empty array, 400, 500, 503 settle nothing.",
     "title": "General Relay",
     "version": "v1"
   },
   "openapi": "3.1.0",
   "paths": {
-    "/v1/vessel": {
+    "/v1/vessels": {
       "get": {
-        "description": "Latest AIS position for one vessel by MMSI (?mmsi=, nine decimal digits), plus everything on file for the hull: FCC licence and USCG record for US vessels, EU MRV verified emissions, the named water body, sea conditions at the nearest monitored chokepoint within 200 km, and active NAVAREA warnings for the region. Sections are null when nothing is on file. Coverage is terrestrial VHF receivers — most of the open ocean will miss. Charged only when a position is found: a miss settles nothing.",
+        "description": "Find vessels by name (substring), IMO (exact), MMSI (exact), and/or spatial bounds. Identity filters (name/imo/mmsi) AND together; spatial is one mode (bbox XOR radius, max 5°×5° or 500 km). At least one filter required; empty call is 400. Returns array of enriched vessel objects (registry, emissions, water_body, chokepoint, warnings), ordered by last_seen DESC, capped at 100. Coverage: terrestrial VHF + AISHub. Charged per non-empty result: empty array, 400, 500, 503 settle nothing.",
         "parameters": [
           {
-            "description": "The vessel's MMSI, exactly nine decimal digits, e.g. 366123456. Sent as text and never as a number: leading zeros are significant (009-prefixed identifiers are coast stations), so 002442000 and 2442000 are not the same vessel.",
+            "description": "Vessel name, case-insensitive substring match. Leading and trailing whitespace is stripped. Example: name=PACIFIC matches \"PACIFIC ENDEAVOUR\". Combines with spatial and other identity filters.",
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "example": "PACIFIC",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          {
+            "description": "IMO number, exact match. A seven-digit international ship identifier. ANDs with name/mmsi/spatial filters.",
+            "in": "query",
+            "name": "imo",
+            "required": false,
+            "schema": {
+              "example": "9394521",
+              "maximum": 9999999,
+              "minimum": 1000000,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The vessel's MMSI, exactly nine decimal digits, e.g. 366123456. Sent as text: leading zeros are significant. ANDs with other identity/spatial filters.",
             "in": "query",
             "name": "mmsi",
-            "required": true,
+            "required": false,
             "schema": {
               "example": "232004521",
               "maxLength": 9,
@@ -25,579 +48,315 @@
               "pattern": "^[0-9]{9}$",
               "type": "string"
             }
+          },
+          {
+            "description": "Southern latitude bound in decimal degrees, for bbox mode. Must be between -90 and 90, and less than or equal to lat_max. The span (lat_max - lat_min) must not exceed 5°.",
+            "in": "query",
+            "name": "lat_min",
+            "required": false,
+            "schema": {
+              "example": "51.0",
+              "maximum": 90,
+              "minimum": -90,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Northern latitude bound in decimal degrees, for bbox mode. Must be between -90 and 90, and greater than or equal to lat_min. The span (lat_max - lat_min) must not exceed 5°.",
+            "in": "query",
+            "name": "lat_max",
+            "required": false,
+            "schema": {
+              "example": "52.0",
+              "maximum": 90,
+              "minimum": -90,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Western longitude bound in decimal degrees, for bbox mode. Must be between -180 and 180, and less than or equal to lon_max. The span (lon_max - lon_min) must not exceed 5°.",
+            "in": "query",
+            "name": "lon_min",
+            "required": false,
+            "schema": {
+              "example": "0.0",
+              "maximum": 180,
+              "minimum": -180,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Eastern longitude bound in decimal degrees, for bbox mode. Must be between -180 and 180, and greater than or equal to lon_min. The span (lon_max - lon_min) must not exceed 5°.",
+            "in": "query",
+            "name": "lon_max",
+            "required": false,
+            "schema": {
+              "example": "1.0",
+              "maximum": 180,
+              "minimum": -180,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Center latitude in decimal degrees, for radius mode. Must be between -90 and 90.",
+            "in": "query",
+            "name": "lat",
+            "required": false,
+            "schema": {
+              "example": "51.5",
+              "maximum": 90,
+              "minimum": -90,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Center longitude in decimal degrees, for radius mode. Must be between -180 and 180.",
+            "in": "query",
+            "name": "lon",
+            "required": false,
+            "schema": {
+              "example": "0.5",
+              "maximum": 180,
+              "minimum": -180,
+              "type": "number"
+            }
+          },
+          {
+            "description": "Search radius in kilometers, for radius mode. Must be between 0.1 and 500.",
+            "in": "query",
+            "name": "radius_km",
+            "required": false,
+            "schema": {
+              "example": "50",
+              "maximum": 500,
+              "minimum": 0.1,
+              "type": "number"
+            }
           }
         ],
         "responses": {
           "200": {
             "content": {
               "application/json": {
-                "example": {
-                  "call_sign": "MDZK7",
-                  "dimensions": {
-                    "beam": 32,
-                    "bow": 172,
-                    "length": 200,
-                    "port": 16,
-                    "starboard": 16,
-                    "stern": 28
-                  },
-                  "emissions": {
-                    "dwt": 63400.0,
-                    "gross_tonnage": 52450.0,
-                    "reporting_year": 2024,
-                    "ship_type": "Container ship",
-                    "technical_efficiency": "EIV (18.42 gCO₂/t·nm)",
-                    "total_co2_emissions_t": 55471.3,
-                    "total_fuel_consumption_t": 17820.5
-                  },
-                  "first_seen": "2026-06-02T09:14:03Z",
-                  "imo_number": 9394521,
-                  "last_seen": "2026-08-10T14:03:53Z",
-                  "mmsi": "232004521",
-                  "name": "PACIFIC ENDEAVOUR",
-                  "navigational_warnings": {
-                    "active": 7,
-                    "areas": [
-                      "4",
-                      "HYDROLANT"
-                    ],
-                    "items": [
-                      {
-                        "excerpt": "ENGLISH CHANNEL. DOVER STRAIT. DERELICT VESSEL ADRIFT IN 51-02N 001-28E AT 081600Z UTC...",
-                        "issue_date": "081653Z AUG 2026",
-                        "msg_number": 812,
-                        "msg_year": 2026,
-                        "nav_area": "HYDROLANT",
-                        "subregion": "24"
-                      }
-                    ],
-                    "scope": "the NAVAREA/HYDRO broadcast areas covering this position, not vessel proximity"
-                  },
-                  "nearest_chokepoint": {
-                    "distance_km": 74.51,
-                    "name": "Strait of Dover",
-                    "sea_state": {
-                      "time": "2026-08-10T12:00:00Z",
-                      "wave_direction_deg": 215,
-                      "wave_height_m": 1.31,
-                      "wave_period_s": 5.9
-                    },
-                    "weather": {
-                      "pressure_hpa": 1013.4,
-                      "sea_surface_temp_c": 17.2,
-                      "swell_wave_height_m": 0.8,
-                      "time": "2026-08-10T14:00:00Z",
-                      "visibility_m": 18000.0,
-                      "wave_direction_deg": 210,
-                      "wave_height_m": 1.24,
-                      "wave_period_s": 5.6,
-                      "wind_direction_deg": 225,
-                      "wind_gusts_kmh": 41.0,
-                      "wind_speed_kmh": 28.4
-                    }
-                  },
-                  "position": {
-                    "age_seconds": 12,
-                    "course_over_ground": 94.2,
-                    "heading": 96,
-                    "latitude": 51.4482,
-                    "longitude": 0.7361,
-                    "msg_type": 1,
-                    "nav_status": 0,
-                    "speed_over_ground": 11.4,
-                    "time": "2026-08-10T14:03:53Z"
-                  },
-                  "registry": null,
-                  "ship_type": 70,
-                  "water_body": {
-                    "mrgid": 4374,
-                    "name": "Thames Estuary",
-                    "note": "a name from a bounding-box gazetteer, for orientation only — not a jurisdictional or navigational claim",
-                    "place_type": "Estuary"
-                  }
-                },
-                "schema": {
-                  "properties": {
-                    "call_sign": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
+                "example": [
+                  {
+                    "call_sign": "MDZK7",
                     "dimensions": {
-                      "properties": {
-                        "beam": {
-                          "type": "integer"
-                        },
-                        "bow": {
-                          "type": "integer"
-                        },
-                        "length": {
-                          "type": "integer"
-                        },
-                        "port": {
-                          "type": "integer"
-                        },
-                        "starboard": {
-                          "type": "integer"
-                        },
-                        "stern": {
-                          "type": "integer"
-                        }
-                      },
-                      "required": [
-                        "bow",
-                        "stern",
-                        "port",
-                        "starboard",
-                        "length",
-                        "beam"
-                      ],
-                      "type": [
-                        "object",
-                        "null"
-                      ]
+                      "beam": 32,
+                      "bow": 172,
+                      "length": 200,
+                      "port": 16,
+                      "starboard": 16,
+                      "stern": 28
                     },
-                    "emissions": {
-                      "properties": {
-                        "dwt": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "gross_tonnage": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "reporting_year": {
-                          "type": [
-                            "integer",
-                            "null"
-                          ]
-                        },
-                        "ship_type": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "technical_efficiency": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        },
-                        "total_co2_emissions_t": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "total_fuel_consumption_t": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "reporting_year",
-                        "ship_type",
-                        "dwt",
-                        "gross_tonnage",
-                        "total_fuel_consumption_t",
-                        "total_co2_emissions_t",
-                        "technical_efficiency"
-                      ],
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    },
-                    "first_seen": {
-                      "format": "date-time",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "imo_number": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "last_seen": {
-                      "format": "date-time",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "mmsi": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "navigational_warnings": {
-                      "properties": {
-                        "active": {
-                          "type": "integer"
-                        },
-                        "areas": {
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "items": {
-                          "items": {
-                            "properties": {
-                              "excerpt": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "issue_date": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              },
-                              "msg_number": {
-                                "type": "integer"
-                              },
-                              "msg_year": {
-                                "type": "integer"
-                              },
-                              "nav_area": {
-                                "type": "string"
-                              },
-                              "subregion": {
-                                "type": [
-                                  "string",
-                                  "null"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "nav_area",
-                              "msg_year",
-                              "msg_number",
-                              "subregion",
-                              "issue_date",
-                              "excerpt"
-                            ],
-                            "type": "object"
-                          },
-                          "type": "array"
-                        },
-                        "scope": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "scope",
-                        "areas",
-                        "active",
-                        "items"
-                      ],
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    },
-                    "nearest_chokepoint": {
-                      "properties": {
-                        "distance_km": {
-                          "type": "number"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "sea_state": {
-                          "properties": {
-                            "time": {
-                              "format": "date-time",
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "wave_direction_deg": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "wave_height_m": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "wave_period_s": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "time",
-                            "wave_height_m",
-                            "wave_direction_deg",
-                            "wave_period_s"
-                          ],
-                          "type": [
-                            "object",
-                            "null"
-                          ]
-                        },
-                        "weather": {
-                          "properties": {
-                            "pressure_hpa": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "sea_surface_temp_c": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "swell_wave_height_m": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "time": {
-                              "format": "date-time",
-                              "type": [
-                                "string",
-                                "null"
-                              ]
-                            },
-                            "visibility_m": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "wave_direction_deg": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "wave_height_m": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "wave_period_s": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "wind_direction_deg": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "wind_gusts_kmh": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            },
-                            "wind_speed_kmh": {
-                              "type": [
-                                "number",
-                                "null"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "time",
-                            "wave_height_m",
-                            "wave_direction_deg",
-                            "wave_period_s",
-                            "swell_wave_height_m",
-                            "wind_speed_kmh",
-                            "wind_gusts_kmh",
-                            "wind_direction_deg",
-                            "visibility_m",
-                            "sea_surface_temp_c",
-                            "pressure_hpa"
-                          ],
-                          "type": [
-                            "object",
-                            "null"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "name",
-                        "distance_km",
-                        "weather",
-                        "sea_state"
-                      ],
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    },
+                    "emissions": null,
+                    "first_seen": "2026-06-02T09:14:03Z",
+                    "imo_number": 9394521,
+                    "last_seen": "2026-08-10T14:03:53Z",
+                    "mmsi": "232004521",
+                    "name": "PACIFIC ENDEAVOUR",
+                    "navigational_warnings": null,
+                    "nearest_chokepoint": null,
                     "position": {
-                      "properties": {
-                        "age_seconds": {
-                          "type": "integer"
-                        },
-                        "course_over_ground": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "heading": {
-                          "type": [
-                            "integer",
-                            "null"
-                          ]
-                        },
-                        "latitude": {
-                          "type": "number"
-                        },
-                        "longitude": {
-                          "type": "number"
-                        },
-                        "msg_type": {
-                          "type": "integer"
-                        },
-                        "nav_status": {
-                          "type": [
-                            "integer",
-                            "null"
-                          ]
-                        },
-                        "speed_over_ground": {
-                          "type": [
-                            "number",
-                            "null"
-                          ]
-                        },
-                        "time": {
-                          "format": "date-time",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "latitude",
-                        "longitude",
-                        "time",
-                        "age_seconds",
-                        "speed_over_ground",
-                        "course_over_ground",
-                        "heading",
-                        "nav_status",
-                        "msg_type"
-                      ],
-                      "type": "object"
+                      "age_seconds": 12,
+                      "course_over_ground": 94.2,
+                      "heading": 96,
+                      "latitude": 51.4482,
+                      "longitude": 0.7361,
+                      "msg_type": 1,
+                      "nav_status": 0,
+                      "speed_over_ground": 11.4,
+                      "time": "2026-08-10T14:03:53Z"
                     },
-                    "registry": {
-                      "properties": {
-                        "fcc": {
-                          "type": [
-                            "object",
-                            "null"
-                          ]
-                        },
-                        "uscg": {
-                          "type": [
-                            "object",
-                            "null"
-                          ]
-                        }
+                    "registry": null,
+                    "ship_type": 70,
+                    "water_body": null
+                  }
+                ],
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "call_sign": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
                       },
-                      "required": [
-                        "fcc",
-                        "uscg"
-                      ],
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    },
-                    "ship_type": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "water_body": {
-                      "properties": {
-                        "mrgid": {
-                          "type": [
-                            "integer",
-                            "null"
-                          ]
+                      "dimensions": {
+                        "properties": {
+                          "beam": {
+                            "type": "integer"
+                          },
+                          "bow": {
+                            "type": "integer"
+                          },
+                          "length": {
+                            "type": "integer"
+                          },
+                          "port": {
+                            "type": "integer"
+                          },
+                          "starboard": {
+                            "type": "integer"
+                          },
+                          "stern": {
+                            "type": "integer"
+                          }
                         },
-                        "name": {
-                          "type": "string"
-                        },
-                        "note": {
-                          "type": "string"
-                        },
-                        "place_type": {
-                          "type": [
-                            "string",
-                            "null"
-                          ]
-                        }
+                        "required": [
+                          "bow",
+                          "stern",
+                          "port",
+                          "starboard",
+                          "length",
+                          "beam"
+                        ],
+                        "type": [
+                          "object",
+                          "null"
+                        ]
                       },
-                      "required": [
-                        "name",
-                        "place_type",
-                        "mrgid",
-                        "note"
-                      ],
-                      "type": [
-                        "object",
-                        "null"
-                      ]
-                    }
+                      "emissions": {
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      },
+                      "first_seen": {
+                        "format": "date-time",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "imo_number": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "last_seen": {
+                        "format": "date-time",
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "mmsi": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "navigational_warnings": {
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      },
+                      "nearest_chokepoint": {
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      },
+                      "position": {
+                        "properties": {
+                          "age_seconds": {
+                            "type": "integer"
+                          },
+                          "course_over_ground": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "heading": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "latitude": {
+                            "type": "number"
+                          },
+                          "longitude": {
+                            "type": "number"
+                          },
+                          "msg_type": {
+                            "type": "integer"
+                          },
+                          "nav_status": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "speed_over_ground": {
+                            "type": [
+                              "number",
+                              "null"
+                            ]
+                          },
+                          "time": {
+                            "format": "date-time",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "latitude",
+                          "longitude",
+                          "time",
+                          "age_seconds",
+                          "speed_over_ground",
+                          "course_over_ground",
+                          "heading",
+                          "nav_status",
+                          "msg_type"
+                        ],
+                        "type": "object"
+                      },
+                      "registry": {
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      },
+                      "ship_type": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "water_body": {
+                        "type": [
+                          "object",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "mmsi",
+                      "name",
+                      "call_sign",
+                      "imo_number",
+                      "ship_type",
+                      "dimensions",
+                      "position",
+                      "first_seen",
+                      "last_seen",
+                      "registry",
+                      "emissions",
+                      "water_body",
+                      "nearest_chokepoint",
+                      "navigational_warnings"
+                    ],
+                    "type": "object"
                   },
-                  "required": [
-                    "mmsi",
-                    "name",
-                    "call_sign",
-                    "imo_number",
-                    "ship_type",
-                    "dimensions",
-                    "position",
-                    "first_seen",
-                    "last_seen",
-                    "registry",
-                    "emissions",
-                    "water_body",
-                    "nearest_chokepoint",
-                    "navigational_warnings"
-                  ],
-                  "type": "object"
+                  "type": "array"
                 }
               }
             },
@@ -607,7 +366,7 @@
             "content": {
               "application/json": {
                 "example": {
-                  "error": "\"mmsi\" must be nine decimal digits, e.g. 366123456 (received 7 characters)"
+                  "error": "bounding box must not exceed 5° × 5° (latitude × longitude), received 6.00° × 7.00°"
                 },
                 "schema": {
                   "properties": {
@@ -622,7 +381,7 @@
                 }
               }
             },
-            "description": "The `mmsi` parameter is missing or is not nine decimal digits. Nothing is settled; fix the request rather than retrying it."
+            "description": "Invalid parameters: coordinates out of range, lat_min > lat_max, bbox exceeds 5° × 5°, radius exceeds 500 km, or both modes/neither mode provided. Nothing is settled; fix the request rather than retrying it."
           },
           "402": {
             "description": "Payment Required"
@@ -631,49 +390,22 @@
             "content": {
               "application/json": {
                 "example": {
-                  "error": "no position on file for MMSI 366123456. Coverage is a network of terrestrial VHF receivers — vessels out of range of every receiver in it, and most of the open ocean, are not covered.",
-                  "last_position_at": "2026-08-10T14:03:53Z",
-                  "mmsi": "366123456",
-                  "vessels": 37,
-                  "window_seconds": 3600
+                  "error": "no route matches this path"
                 },
                 "schema": {
                   "properties": {
                     "error": {
                       "type": "string"
-                    },
-                    "last_position_at": {
-                      "format": "date-time",
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "mmsi": {
-                      "type": "string"
-                    },
-                    "vessels": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ]
-                    },
-                    "window_seconds": {
-                      "type": "integer"
                     }
                   },
                   "required": [
-                    "error",
-                    "mmsi",
-                    "vessels",
-                    "last_position_at",
-                    "window_seconds"
+                    "error"
                   ],
                   "type": "object"
                 }
               }
             },
-            "description": "No position on file for that MMSI. Nothing is settled. `vessels` is how many distinct MMSIs were heard in the last `window_seconds`: a positive count means this hull is out of coverage and another is worth trying, and 0 means the receivers are silent and every subsequent lookup will miss too — stop rather than working through a list. Null means the count itself could not be taken."
+            "description": "Route not found. Nothing is settled. This handler returns 200 with an empty array when no vessels are in the area, not 404; a 404 only occurs if the route path itself is wrong."
           },
           "500": {
             "content": {
@@ -694,7 +426,7 @@
                 }
               }
             },
-            "description": "The position database answered with something this service could not read — a defect on our side. Nothing is settled, and retrying will not clear it."
+            "description": "The position database returned data this service could not read. Nothing is settled, and retrying will not clear it."
           },
           "503": {
             "content": {
@@ -715,7 +447,7 @@
                 }
               }
             },
-            "description": "The position database is unreachable. Nothing is settled, and this says nothing about the vessel — retry after the number of seconds in `Retry-After`.",
+            "description": "The position database is unreachable. Nothing is settled — retry after the number of seconds in Retry-After.",
             "headers": {
               "Retry-After": {
                 "description": "Seconds to wait before retrying.",
@@ -727,19 +459,19 @@
             }
           }
         },
-        "summary": "Get one vessel's position, registry and local conditions",
+        "summary": "Search vessels by identity, location, or both",
         "x-payment-info": {
           "offers": [
             {
-              "amount": "5000",
+              "amount": "20000",
               "currency": "USDC",
-              "description": "up to 0.005 USDC",
-              "feePayer": "HX97oTB6wbJ3TtP4sSSYfFuiBSvJYm4ShqyagXGrSQ8r",
+              "description": "0.02 USDC",
               "intent": "charge",
               "method": "x402",
               "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
               "payTo": "9BpudpCnChrpp4KfnxAE3r2TXKJTLmvVpF8WSViuaJZ9",
-              "scheme": "upto"
+              "scheme": "exact",
+              "feePayer": "HX97oTB6wbJ3TtP4sSSYfFuiBSvJYm4ShqyagXGrSQ8r"
             }
           ]
         }

--- a/providers/general-relay/maritime/openapi.json
+++ b/providers/general-relay/maritime/openapi.json
@@ -19,6 +19,10 @@
             "name": "mmsi",
             "required": true,
             "schema": {
+              "example": "232004521",
+              "maxLength": 9,
+              "minLength": 9,
+              "pattern": "^[0-9]{9}$",
               "type": "string"
             }
           }
@@ -599,8 +603,128 @@
             },
             "description": "Successful response"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": "\"mmsi\" must be nine decimal digits, e.g. 366123456 (received 7 characters)"
+                },
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The `mmsi` parameter is missing or is not nine decimal digits. Nothing is settled; fix the request rather than retrying it."
+          },
           "402": {
             "description": "Payment Required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": "no position on file for MMSI 366123456. Coverage is a network of terrestrial VHF receivers — vessels out of range of every receiver in it, and most of the open ocean, are not covered.",
+                  "last_position_at": "2026-08-10T14:03:53Z",
+                  "mmsi": "366123456",
+                  "vessels": 37,
+                  "window_seconds": 3600
+                },
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "last_position_at": {
+                      "format": "date-time",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "mmsi": {
+                      "type": "string"
+                    },
+                    "vessels": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    },
+                    "window_seconds": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "mmsi",
+                    "vessels",
+                    "last_position_at",
+                    "window_seconds"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "No position on file for that MMSI. Nothing is settled. `vessels` is how many distinct MMSIs were heard in the last `window_seconds`: a positive count means this hull is out of coverage and another is worth trying, and 0 means the receivers are silent and every subsequent lookup will miss too — stop rather than working through a list. Null means the count itself could not be taken."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": "the position database returned data this service could not read; this is a defect on our side and retrying will not clear it"
+                },
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The position database answered with something this service could not read — a defect on our side. Nothing is settled, and retrying will not clear it."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "error": "the position database is unreachable; this is a transient fault on our side, not a statement about the vessel — retry after 5s"
+                },
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The position database is unreachable. Nothing is settled, and this says nothing about the vessel — retry after the number of seconds in `Retry-After`.",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying.",
+                "example": 5,
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
           }
         },
         "summary": "Get one vessel's position, registry and local conditions",

--- a/providers/general-relay/maritime/openapi.json
+++ b/providers/general-relay/maritime/openapi.json
@@ -1,0 +1,86 @@
+{
+  "info": {
+    "title": "General Relay",
+    "version": "v1"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/v1/vessel": {
+      "get": {
+        "description": "Latest AIS position for one vessel by MMSI (?mmsi=, exactly nine decimal digits): latitude, longitude, speed, course, heading, report time, age_seconds, plus name, call sign, IMO and dimensions once a static report is seen. Coverage is a network of terrestrial VHF receivers, so vessels far from any receiver and most of the open ocean will miss. Latest position only, no history. You are charged only when a position is found: a miss settles nothing.",
+        "parameters": [
+          {
+            "description": "The vessel's MMSI, exactly nine decimal digits, e.g. 366123456. Sent as text and never as a number: leading zeros are significant (009-prefixed identifiers are coast stations), so 002442000 and 2442000 are not the same vessel.",
+            "in": "query",
+            "name": "mmsi",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "call_sign": "MDZK7",
+                  "dimensions": {
+                    "beam": 32,
+                    "bow": 172,
+                    "length": 200,
+                    "port": 16,
+                    "starboard": 16,
+                    "stern": 28
+                  },
+                  "first_seen": "2026-06-02T09:14:03Z",
+                  "imo_number": 9394521,
+                  "last_seen": "2026-08-10T14:03:53Z",
+                  "mmsi": "232004521",
+                  "name": "PACIFIC ENDEAVOUR",
+                  "position": {
+                    "age_seconds": 12,
+                    "course_over_ground": 94.2,
+                    "heading": 96,
+                    "latitude": 51.4482,
+                    "longitude": 0.7361,
+                    "msg_type": 1,
+                    "nav_status": 0,
+                    "speed_over_ground": 11.4,
+                    "time": "2026-08-10T14:03:53Z"
+                  },
+                  "ship_type": 70
+                }
+              }
+            },
+            "description": "Successful response"
+          },
+          "402": {
+            "description": "Payment Required"
+          }
+        },
+        "summary": "Get the latest AIS position for one vessel by MMSI",
+        "x-payment-info": {
+          "offers": [
+            {
+              "amount": "5000",
+              "currency": "USDC",
+              "description": "up to 0.005 USDC",
+              "feePayer": "HX97oTB6wbJ3TtP4sSSYfFuiBSvJYm4ShqyagXGrSQ8r",
+              "intent": "charge",
+              "method": "x402",
+              "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+              "payTo": "9BpudpCnChrpp4KfnxAE3r2TXKJTLmvVpF8WSViuaJZ9",
+              "scheme": "upto"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.generalrelay.xyz"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `providers/general-relay/maritime/` with `PAY.md` and `openapi.json`
- One paid route: `GET /v1/vessels` — search vessels by identity, location, or both
- Optional filters (at least one required): `name` (substring), `imo` (exact), `mmsi` (exact 9-digit string), bbox (`lat_min`/`lat_max`/`lon_min`/`lon_max`, max 5°×5°) XOR radius (`lat`/`lon`/`radius_km`, max 500 km). Identity filters AND together
- $0.02 per non-empty result in USDC on Solana mainnet, `x402-exact`. **Charged only when the result array is non-empty** — an empty array, 400, 500 or 503 settles nothing
- Operator sponsors the transaction fee, caller only needs USDC
- Coverage is terrestrial VHF + AISHub, not global. Name and IMO can be null
- Old paths are gone: `GET /v1/vessel` and `GET /v1/vessel/search` return 404 and are not listed

## Test Plan

```
$ pay catalog check providers/general-relay/maritime/PAY.md -v
  GET  v1/vessels?...  OK 402 x402  USDC (68ms)
  PASS general-relay/maritime (1/1)
│ PAY.md check successful
│ 1 endpoint tested across 1 provider
│ 1/1 gates compatible with Solana
```

Verified against live production at https://api.generalrelay.xyz (2026-08-25): 402 `accepts[0].scheme` is `exact`, amount `20000`, network `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`. Old paths return 404.