### PR TITLE
feat(catalog): add apify/web-data

### DIFF
--- a/providers/apify/web-data/PAY.md
+++ b/providers/apify/web-data/PAY.md
@@ -1,0 +1,77 @@
+---
+name: web-data
+title: "Apify"
+description: "Apify is a marketplace of tools for AI, reachable with a prepaid token. Pay once in Solana USDC or USDT to mint a spend-capped Apify API token, then run tens of thousands of Actors that scrape, crawl, and extract structured data from any website."
+use_case: "Use for web scraping, crawling, and structured data extraction from social media, e-commerce sites, search engines, maps, travel, and review sites when an agent needs many calls under one prepaid budget instead of paying per request."
+category: data
+service_url: https://agi.apify.com
+openapi:
+  path: openapi.json
+---
+
+Apify hosts tens of thousands of ready-to-run cloud programs called Actors.
+Each one takes JSON input and returns a dataset: search results, product
+listings, social media profiles, map places, reviews, job postings, or the
+rendered content of an arbitrary URL. Actors handle the parts of web data
+collection an agent should not have to solve, including browser rendering,
+proxy rotation, retries, pagination, and anti-bot handling.
+
+`agi.apify.com` sells access to that catalog as a prepaid credential. An agent
+pays once on Solana, receives a spend-capped Apify API token, and then calls
+`https://api.apify.com` or `https://mcp.apify.com` with
+`Authorization: Bearer <token>` until the balance runs out. No account, no
+signup, and no API key provisioning.
+
+## Payment flow
+
+1. `POST /protocols/x402/prepaid-tokens` with `{"amount":"<usd>","currency":"usd"}`
+   and no payment credential. The response is `402` with the challenge in both
+   the `payment-required` response header (base64 JSON) and the body. The
+   `accepts` array advertises `exact` on Solana USDC, Solana USDT, and Base
+   USDC.
+2. Sign the chosen requirement and retry the same request with
+   `payment-signature: <base64 JSON payload>`. Note the header name: this
+   service reads `payment-signature`, not `X-PAYMENT`.
+3. `201` returns `{"token": "...", "remainingBalanceUsd": ..., "expiresAt": "..."}`.
+4. Call Apify with the token. `agi.apify.com` is off the request path from here
+   on; every Actor run, API call, and MCP tool call meters against the token's
+   balance.
+5. `GET /prepaid-tokens/balance` with the same bearer token returns the
+   remaining balance and expiry.
+
+MPP works the same way on `POST /protocols/mpp/prepaid-tokens`, with the
+credential presented as `Authorization: Payment <proof>` and challenges
+delivered in `WWW-Authenticate` headers. That rail settles in push mode on
+Tempo (chain ID 4217) or Solana, and its challenges expire after five minutes.
+
+## Spend-aware usage
+
+- Size one token to the whole job. There is no top-up: `POST /prepaid-tokens/top-up`
+  returns `501`, so an exhausted token means buying another one.
+- The minimum purchase is $1. Amounts are buyer-chosen in USD with at most two
+  decimal places, and the challenge quotes the same amount on every rail.
+- Unused balance is not refundable and the prepaid account is deleted after its
+  TTL, currently 14 days. Buy for near-term work rather than banking credit.
+- Pick a purpose-built Actor over a general-purpose crawler. A Google Maps
+  Actor costs less for map places than crawling and parsing the pages yourself.
+- Actor pricing varies per Actor and is published on its Apify Store page.
+  Check it before a large run, and cap `maxItems` or an equivalent input limit
+  so a broad crawl cannot drain the balance.
+- Read `GET /prepaid-tokens/balance` instead of re-deriving spend from run
+  results.
+- Reuse dataset IDs. A finished Actor run keeps its dataset, so re-reading
+  results costs nothing while re-running the Actor costs the balance again.
+
+## What this listing does and does not cover
+
+The two paid endpoints sell a credential, not a result. The committed OpenAPI
+document describes `agi.apify.com` only, which is the surface that returns the
+402 challenges and mints the token.
+
+The endpoints that return web data are `https://api.apify.com` (documented at
+https://docs.apify.com/api/v2) and `https://mcp.apify.com`. Both authenticate
+with the minted token and are deliberately outside this spec, because neither
+is payment-gated on its own: they are bearer-authenticated and metered against
+the prepaid balance. This mirrors `venice/ai`, where `POST /x402/top-up` is the
+paid endpoint and the inference routes consume the resulting balance, and
+`dtelecom/voice`, where the only paid endpoints are credit purchases.

--- a/providers/apify/web-data/PAY.md
+++ b/providers/apify/web-data/PAY.md
@@ -1,26 +1,26 @@
 ---
 name: web-data
 title: "Apify"
-description: "Apify is a marketplace of tools for AI, reachable with a prepaid token. Pay once in Solana USDC or USDT to mint a spend-capped Apify API token, then run tens of thousands of Actors that scrape, crawl, and extract structured data from any website."
-use_case: "Use for web scraping, crawling, and structured data extraction from social media, e-commerce sites, search engines, maps, travel, and review sites when an agent needs many calls under one prepaid budget instead of paying per request."
+description: "Apify Actors for web scraping, crawling, and browser automation, returning search results, product listings, social profiles, map places, reviews, job postings, structured datasets, and rendered page content from public websites."
+use_case: "Use for web scraping, crawling, and structured data extraction (Google Maps places, Instagram profiles, Amazon listings, Google search results, reviews, job boards, site-to-markdown crawls) when an agent needs many calls under one prepaid budget."
 category: data
 service_url: https://agi.apify.com
 openapi:
   path: openapi.json
 ---
 
-Apify hosts tens of thousands of ready-to-run cloud programs called Actors.
-Each one takes JSON input and returns a dataset: search results, product
-listings, social media profiles, map places, reviews, job postings, or the
-rendered content of an arbitrary URL. Actors handle the parts of web data
-collection an agent should not have to solve, including browser rendering,
-proxy rotation, retries, pagination, and anti-bot handling.
+Apify hosts thousands of ready-to-run cloud programs called Actors. Most take
+JSON input and return a dataset: search results, product listings, social media
+profiles, map places, reviews, job postings, or the rendered content of a URL.
+Actors handle the parts of collecting data from websites that an agent should
+not have to solve, including browser rendering, proxy rotation, retries, pagination, and
+anti-bot handling.
 
 `agi.apify.com` sells access to that catalog as a prepaid credential. An agent
 pays once on Solana, receives a spend-capped Apify API token, and then calls
 `https://api.apify.com` or `https://mcp.apify.com` with
-`Authorization: Bearer <token>` until the balance runs out. No account, no
-signup, and no API key provisioning.
+`Authorization: Bearer <token>` until the balance runs out. No Apify account or
+signup needed.
 
 ## Payment flow
 
@@ -29,9 +29,10 @@ signup, and no API key provisioning.
    the `payment-required` response header (base64 JSON) and the body. The
    `accepts` array advertises `exact` on Solana USDC, Solana USDT, and Base
    USDC.
-2. Sign the chosen requirement and retry the same request with
-   `payment-signature: <base64 JSON payload>`. Note the header name: this
-   service reads `payment-signature`, not `X-PAYMENT`.
+2. Sign the chosen requirement and retry the same request with the credential
+   in the `payment-signature` header (base64 JSON). These are the x402 v2
+   header names; clients that only send the v1 `X-PAYMENT` header will not
+   work.
 3. `201` returns `{"token": "...", "remainingBalanceUsd": ..., "expiresAt": "..."}`.
 4. Call Apify with the token. `agi.apify.com` is off the request path from here
    on; every Actor run, API call, and MCP tool call meters against the token's
@@ -39,10 +40,10 @@ signup, and no API key provisioning.
 5. `GET /prepaid-tokens/balance` with the same bearer token returns the
    remaining balance and expiry.
 
-MPP works the same way on `POST /protocols/mpp/prepaid-tokens`, with the
-credential presented as `Authorization: Payment <proof>` and challenges
-delivered in `WWW-Authenticate` headers. That rail settles in push mode on
-Tempo (chain ID 4217) or Solana, and its challenges expire after five minutes.
+MPP works the same way on `POST /protocols/mpp/prepaid-tokens`: the credential
+travels in `Authorization: Payment <proof>` and challenges arrive in
+`WWW-Authenticate` headers. That rail settles a `charge` on Tempo (chain ID
+4217) or Solana, in USDC or USDT, and its challenges expire after five minutes.
 
 ## Spend-aware usage
 
@@ -59,16 +60,16 @@ Tempo (chain ID 4217) or Solana, and its challenges expire after five minutes.
   so a broad crawl cannot drain the balance.
 - Read `GET /prepaid-tokens/balance` instead of re-deriving spend from run
   results.
-- Reuse dataset IDs. A finished Actor run keeps its dataset, so re-reading
-  results costs nothing while re-running the Actor costs the balance again.
+- Reuse dataset IDs. A finished Actor run keeps its dataset, so reading the
+  results again is far cheaper than re-running the Actor.
 
 ## What this listing does and does not cover
 
-The two paid endpoints sell a credential, not a result. The committed OpenAPI
+The two paid endpoints sell a credential: a prepaid Apify API token. The committed OpenAPI
 document describes `agi.apify.com` only, which is the surface that returns the
 402 challenges and mints the token.
 
-The endpoints that return web data are `https://api.apify.com` (documented at
+The endpoints that return the data are `https://api.apify.com` (documented at
 https://docs.apify.com/api/v2) and `https://mcp.apify.com`. Both authenticate
 with the minted token and are deliberately outside this spec, because neither
 is payment-gated on its own: they are bearer-authenticated and metered against

--- a/providers/apify/web-data/openapi.json
+++ b/providers/apify/web-data/openapi.json
@@ -17,6 +17,10 @@
   "paths": {
     "/protocols": {
       "get": {
+        "operationId": "listProtocols",
+        "tags": [
+          "protocols"
+        ],
         "summary": "List supported payment protocols",
         "security": [],
         "responses": {
@@ -61,6 +65,10 @@
     },
     "/protocols/x402/prepaid-tokens": {
       "post": {
+        "operationId": "buyPrepaidTokenWithX402",
+        "tags": [
+          "prepaid-tokens"
+        ],
         "summary": "Buy a prepaid token with x402",
         "description": "Send `{\"amount\":\"<usd>\",\"currency\":\"usd\"}` as a JSON body (or `?amount=<usd>&currency=usd` in the query). Returns a 402 x402 challenge without `payment-signature`; returns an Apify API token after a valid x402 exact payment.",
         "requestBody": {
@@ -81,7 +89,8 @@
                     "enum": [
                       "usd"
                     ],
-                    "description": "Payment currency. Only \"usd\" is supported."
+                    "description": "Payment currency. Only \"usd\" is supported.",
+                    "example": "usd"
                   }
                 },
                 "required": [
@@ -89,6 +98,10 @@
                   "currency"
                 ],
                 "additionalProperties": false
+              },
+              "example": {
+                "amount": "2",
+                "currency": "usd"
               }
             }
           }
@@ -154,6 +167,10 @@
     },
     "/protocols/mpp/prepaid-tokens": {
       "post": {
+        "operationId": "buyPrepaidTokenWithMpp",
+        "tags": [
+          "prepaid-tokens"
+        ],
         "summary": "Buy a prepaid token with MPP",
         "description": "Send `{\"amount\":\"<usd>\",\"currency\":\"usd\"}` as a JSON body (or `?amount=<usd>&currency=usd` in the query). Returns a 402 MPP challenge without `Authorization: Payment`; returns an Apify API token after a valid Tempo or Solana charge payment.",
         "requestBody": {
@@ -174,7 +191,8 @@
                     "enum": [
                       "usd"
                     ],
-                    "description": "Payment currency. Only \"usd\" is supported."
+                    "description": "Payment currency. Only \"usd\" is supported.",
+                    "example": "usd"
                   }
                 },
                 "required": [
@@ -182,6 +200,10 @@
                   "currency"
                 ],
                 "additionalProperties": false
+              },
+              "example": {
+                "amount": "2",
+                "currency": "usd"
               }
             }
           }
@@ -258,6 +280,10 @@
     },
     "/prepaid-tokens/balance": {
       "get": {
+        "operationId": "readPrepaidTokenBalance",
+        "tags": [
+          "prepaid-tokens"
+        ],
         "summary": "Read prepaid token balance",
         "security": [
           {

--- a/providers/apify/web-data/openapi.json
+++ b/providers/apify/web-data/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Apify AGI",
+    "title": "Apify",
     "version": "1.0.0",
-    "description": "Buy prepaid, spend-capped Apify API tokens through agentic payment protocols.",
+    "description": "Apify is the largest and most trusted marketplace of tools for web scraping, crawling, data extraction, and automation. Buy a prepaid, spend-capped Apify API token to unlock Actors that extract structured data from social media, e-commerce sites, search engines, maps, travel sites, or any other website — turning the open web into a real-time data source for research, lead generation, and monitoring. Get started: buy a token and start calling Actors in seconds.",
     "x-guidance": "Buy a prepaid, spend-capped Apify API token by paying for it with an agentic payment protocol. Call GET /protocols/x402/prepaid-tokens?amount=<usd>&currency=usd (x402 rail) or /protocols/mpp/prepaid-tokens?amount=<usd>&currency=usd (MPP rail, Tempo or Solana). With no payment credential the endpoint returns a 402 challenge; satisfy it and retry the same request to receive a token. The amount is buyer-chosen (minimum $1); tokens expire in 14 days. Use the returned token as Authorization: Bearer <token> against https://api.apify.com. Read the remaining balance at GET /prepaid-tokens/balance with the same bearer token.",
     "contact": {
       "email": "ai@apify.com"
@@ -70,7 +70,7 @@
           "prepaid-tokens"
         ],
         "summary": "Buy a prepaid token with x402",
-        "description": "Send `{\"amount\":\"<usd>\",\"currency\":\"usd\"}` as a JSON body (or `?amount=<usd>&currency=usd` in the query). Returns a 402 x402 challenge without `payment-signature`; returns an Apify API token after a valid x402 exact payment.",
+        "description": "Buy access to Apify's Actors with x402. Send `{\"amount\":\"<usd>\",\"currency\":\"usd\"}` as a JSON body (or `?amount=<usd>&currency=usd` in the query). Returns a 402 x402 challenge without `payment-signature`; returns an Apify API token after a valid x402 exact payment.",
         "requestBody": {
           "required": true,
           "content": {
@@ -172,7 +172,7 @@
           "prepaid-tokens"
         ],
         "summary": "Buy a prepaid token with MPP",
-        "description": "Send `{\"amount\":\"<usd>\",\"currency\":\"usd\"}` as a JSON body (or `?amount=<usd>&currency=usd` in the query). Returns a 402 MPP challenge without `Authorization: Payment`; returns an Apify API token after a valid Tempo or Solana charge payment.",
+        "description": "Buy access to Apify's Actors with MPP. Send `{\"amount\":\"<usd>\",\"currency\":\"usd\"}` as a JSON body (or `?amount=<usd>&currency=usd` in the query). Returns a 402 MPP challenge without `Authorization: Payment`; returns an Apify API token after a valid Tempo or Solana charge payment.",
         "requestBody": {
           "required": true,
           "content": {

--- a/providers/apify/web-data/openapi.json
+++ b/providers/apify/web-data/openapi.json
@@ -1,0 +1,307 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Apify AGI",
+    "version": "1.0.0",
+    "description": "Buy prepaid, spend-capped Apify API tokens through agentic payment protocols.",
+    "x-guidance": "Buy a prepaid, spend-capped Apify API token by paying for it with an agentic payment protocol. Call GET /protocols/x402/prepaid-tokens?amount=<usd>&currency=usd (x402 rail) or /protocols/mpp/prepaid-tokens?amount=<usd>&currency=usd (MPP rail, Tempo or Solana). With no payment credential the endpoint returns a 402 challenge; satisfy it and retry the same request to receive a token. The amount is buyer-chosen (minimum $1); tokens expire in 14 days. Use the returned token as Authorization: Bearer <token> against https://api.apify.com. Read the remaining balance at GET /prepaid-tokens/balance with the same bearer token.",
+    "contact": {
+      "email": "ai@apify.com"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://agi.apify.com"
+    }
+  ],
+  "paths": {
+    "/protocols": {
+      "get": {
+        "summary": "List supported payment protocols",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Supported protocols.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "protocols": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "protocols"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/protocols/x402/prepaid-tokens": {
+      "post": {
+        "summary": "Buy a prepaid token with x402",
+        "description": "Send `{\"amount\":\"<usd>\",\"currency\":\"usd\"}` as a JSON body (or `?amount=<usd>&currency=usd` in the query). Returns a 402 x402 challenge without `payment-signature`; returns an Apify API token after a valid x402 exact payment.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "string",
+                    "pattern": "^\\d+(\\.\\d{1,2})?$",
+                    "description": "Prepaid amount in USD (e.g. \"5\" or \"1.50\"). Minimum $1.",
+                    "example": "2"
+                  },
+                  "currency": {
+                    "type": "string",
+                    "enum": [
+                      "usd"
+                    ],
+                    "description": "Payment currency. Only \"usd\" is supported."
+                  }
+                },
+                "required": [
+                  "amount",
+                  "currency"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "1.00"
+          },
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ]
+        },
+        "responses": {
+          "201": {
+            "description": "Prepaid Apify API token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "Apify API token; use as Authorization: Bearer <token>."
+                    },
+                    "remainingBalanceUsd": {
+                      "type": "number"
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "token",
+                    "remainingBalanceUsd",
+                    "expiresAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid amount or currency."
+          },
+          "402": {
+            "description": "x402 payment challenge.",
+            "headers": {
+              "payment-required": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Base64-encoded x402 payment-required JSON."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/protocols/mpp/prepaid-tokens": {
+      "post": {
+        "summary": "Buy a prepaid token with MPP",
+        "description": "Send `{\"amount\":\"<usd>\",\"currency\":\"usd\"}` as a JSON body (or `?amount=<usd>&currency=usd` in the query). Returns a 402 MPP challenge without `Authorization: Payment`; returns an Apify API token after a valid Tempo or Solana charge payment.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "string",
+                    "pattern": "^\\d+(\\.\\d{1,2})?$",
+                    "description": "Prepaid amount in USD (e.g. \"5\" or \"1.50\"). Minimum $1.",
+                    "example": "2"
+                  },
+                  "currency": {
+                    "type": "string",
+                    "enum": [
+                      "usd"
+                    ],
+                    "description": "Payment currency. Only \"usd\" is supported."
+                  }
+                },
+                "required": [
+                  "amount",
+                  "currency"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-payment-info": {
+          "price": {
+            "mode": "dynamic",
+            "currency": "USD",
+            "min": "1.00"
+          },
+          "protocols": [
+            {
+              "mpp": {
+                "method": "tempo",
+                "intent": "charge",
+                "currency": "USD"
+              }
+            },
+            {
+              "mpp": {
+                "method": "solana",
+                "intent": "charge",
+                "currency": "USD"
+              }
+            }
+          ]
+        },
+        "responses": {
+          "201": {
+            "description": "Prepaid Apify API token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "Apify API token; use as Authorization: Bearer <token>."
+                    },
+                    "remainingBalanceUsd": {
+                      "type": "number"
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "token",
+                    "remainingBalanceUsd",
+                    "expiresAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid amount or currency."
+          },
+          "402": {
+            "description": "MPP payment challenge.",
+            "headers": {
+              "WWW-Authenticate": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "MPP payment challenge."
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prepaid-tokens/balance": {
+      "get": {
+        "summary": "Read prepaid token balance",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prepaid token balance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "remainingBalanceUsd": {
+                      "type": "number"
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "remainingBalanceUsd",
+                    "expiresAt"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid token."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `apify/web-data`: Apify's agent payment gateway, `agi.apify.com`, as a two-level native provider with the OpenAPI spec committed as a sidecar.

Apify hosts thousands of Actors: cloud programs that take JSON input and return structured data from websites, such as search results, product listings, social profiles, map places, reviews, job postings, or a page rendered to markdown.

`agi.apify.com` sells access to that catalog as a prepaid credential. An agent pays once in Solana USDC or USDT, gets a spend-capped Apify API token, and calls `api.apify.com` or `mcp.apify.com` with it until the balance runs out. No Apify account needed.

## Summary

- `PAY.md` with the payment flow, spend-aware usage, and a section stating plainly what the spec does and does not cover.
- `openapi.json` is the document the service generates and serves at `https://agi.apify.com/openapi.json`, pretty-printed with `jq .` and otherwise unmodified. It matched production on September 2, 2026, and was refreshed in this PR after `apify/apify-agi#110` changed the title and descriptions.
- Category `data`. Happy to change the FQN or category if you'd prefer something else.

## Payment model

What the two paid endpoints sell is a credential: a prepaid Apify API token. Both return a decodable Solana 402 accepting USDC and USDT (x402 `exact` on `POST /protocols/x402/prepaid-tokens`, MPP `charge` on `POST /protocols/mpp/prepaid-tokens`). The data then comes from `api.apify.com` and `mcp.apify.com`, which are bearer-authenticated and metered against the prepaid balance, so they are outside this spec. Same shape as the merged `venice/ai` (`POST /x402/top-up` funds a credit balance) and `dtelecom/voice` (paid credit purchase, then a bearer token) listings.

## Verified on Solana mainnet

Bought a $1 token through the x402 endpoint with the `pay` CLI on September 2, 2026:

```
pay --mainnet --x402 curl 'https://agi.apify.com/protocols/x402/prepaid-tokens?amount=1&currency=usd'
→ 201 {"token":"apify_api_…","remainingBalanceUsd":1,"expiresAt":"2026-09-16T17:16:36.397Z"}
```

- Transaction: https://solscan.io/tx/5o8dLmEjontizN11tDhsuP67YsXyBxi4ZQ9UH5wMjEp1Goagfcjab2tYRnJ2jCAbRZfdU7XUvATjuatESLzxqK8T (1 USDC from `5VxN8jLjSrKNj2S71MzkJycP4BXgoN3ZQbu5PXn21boi` to the service's payTo `ECUPkq6DP8VUSEueL4qNznyNDJLwu6PQhnMQ5cuZsTLH`, fee sponsored by the CDP facilitator)
- `GET /prepaid-tokens/balance` with the minted token returned `remainingBalanceUsd: 1`, and the same token authenticates against `api.apify.com` (`GET /v2/users/me` resolves to a prepaid account).

## Test plan

- `pay catalog check providers/apify/web-data/PAY.md -v` (pay 0.28.0): `PASS providers/apify/web-data (2/2)`, `2/2 gates compatible with Solana`. `GET /protocols` is free and `GET /prepaid-tokens/balance` is `auth_required`, both indeterminate and non-blocking.
- `pay catalog check . --changed-from upstream/main`: `Changed providers check successful`.
- `pay catalog check . --no-probe`: passes; the pre-existing warnings are all in `solana-foundation/google/*` and `solana-foundation/alibaba/*`.
- `curl -fsSL https://agi.apify.com/openapi.json | jq . | diff - providers/apify/web-data/openapi.json` is empty.

Commits are signed. If there's a partner-marketing track for teams joining the catalog, I'd be glad to coordinate an announcement on our side.
