### PR TITLE
Add You.com Web Search and Finance Research providers

### DIFF
--- a/providers/you-com/finance-research/PAY.md
+++ b/providers/you-com/finance-research/PAY.md
@@ -1,0 +1,50 @@
+---
+name: finance-research
+title: "You.com"
+description: "You.com Finance Research API: agentic deep research over a finance-optimized index, returning a synthesized, citation-backed answer to financial questions on earnings, filings, guidance, and market data. Async: paying returns a jobId to poll for results."
+use_case: "Use for financial research questions, earnings and guidance analysis, SEC filings review, market and company analysis, ticker comparisons, and trading or investment research that needs a reasoned answer with cited sources."
+category: finance
+service_url: https://api.you.com
+endpoints:
+  - method: POST
+    path: "v1/finance_research"
+    resource: finance_research
+    description: "Run agentic research on a financial question and return a synthesized answer with cited sources; JSON body takes input and a research_effort tier"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.11
+---
+
+Agentic research on financial questions, running multiple searches over a
+finance-optimized index and returning a synthesized answer with cited sources.
+Suited to earnings and guidance analysis, filings review, and market or
+company questions where an agent needs reasoning plus citations rather than
+raw search results.
+
+JSON body: `input` (the financial question, required) and `research_effort`
+(the depth tier, default `deep`). Pricing is fixed per tier: `deep` is $0.11
+and `exhaustive` is $0.50 per call. The 402 is issued before the body is
+validated, so the quote always reflects the tier you sent; confirm the tier is
+one the API accepts before paying against the quote.
+
+Payment is x402 V2, quoted in USDC on Solana mainnet and Base, with no API key
+and no account. The same 402 also advertises MPP terms (USDC on Tempo). The
+call is asynchronous: paying returns a `jobId`, and the result is fetched from
+the SIWX-authenticated `poll_url` in the response. Deep research typically
+takes 1 to 3 minutes.
+
+## Spend-aware usage
+
+- Default to `deep` ($0.11). Reach for `exhaustive` ($0.50) only when a deep
+  run has already proven insufficient for the question.
+- Ask one well-formed question per call rather than splitting a question into
+  several paid runs; the research is multi-step on the server side.
+- For simple fact lookups (a single price, a headline), a $0.005 Web Search
+  call is usually enough; reserve Finance Research for questions that need
+  synthesis across sources.
+- Poll the returned `poll_url` for completion instead of resubmitting the
+  request; a resubmission is a second paid run.

--- a/providers/you-com/search/PAY.md
+++ b/providers/you-com/search/PAY.md
@@ -1,0 +1,52 @@
+---
+name: search
+title: "You.com"
+description: "You.com Web Search API: real-time web and news search returning ranked results grouped by section (results.web, results.news) with URLs, titles, descriptions, and snippets. Optional livecrawl adds live page contents per result for LLM and agent grounding."
+use_case: "Use for real-time web search, news and current-events lookup, fact-checking, company and market research, and grounding LLM or agent answers with fresh, citable web results, including live page contents via livecrawl."
+category: search
+service_url: https://api.you.com
+endpoints:
+  - method: GET
+    path: "v1/search"
+    resource: search
+    description: "Search the web and news in real time, returning ranked results with URLs, titles, descriptions, and snippets grouped into web and news sections"
+    pricing:
+      dimensions:
+        - direction: usage
+          unit: requests
+          scale: 1
+          tiers:
+            - price_usd: 0.005
+---
+
+Real-time web search built for LLMs and agents. One GET call returns ranked
+results grouped into `results.web` and `results.news`, each with `url`,
+`title`, and `description`; web results also carry query-matched `snippets`.
+Response `metadata` includes the query, a `search_uuid`, and latency.
+
+Query parameters: `query` (required), `count` (1 to 100, default 10),
+`livecrawl` (`web` | `news` | `all`, fetches live page contents for results),
+`country`, `freshness` (`day` | `week` | `month` | `year`, or a
+`YYYY-MM-DDtoYYYY-MM-DD` range), `language`, and domain filters.
+
+Payment is x402 V2, quoted in USDC on Solana mainnet and Base, with no API key
+and no account. The base call is $0.005. Adding `livecrawl` raises the quote
+by $0.001 per result, so `count=10` with livecrawl quotes $0.015. The same
+endpoint also advertises MPP terms (USDC on Tempo) in the same 402. If you
+need a POST form, `/v1/agents/search` accepts machine payments on both GET and
+POST with identical pricing and response shape.
+
+## Spend-aware usage
+
+- Set `count` to the smallest number that answers the task; with `livecrawl`
+  the price scales linearly with `count`.
+- Omit `livecrawl` unless you will actually read page contents; snippets are
+  included at the base price.
+- Sign against the exact 402 you were handed. Terms are priced per request
+  shape, so a quote fetched for one `count` or `livecrawl` setting is not
+  valid for another.
+- Terms stay valid for 10 minutes. Reuse the challenge you already hold
+  instead of minting a new one per attempt; more than 10 unpaid challenge
+  requests per minute returns 429.
+- Use `freshness` and domain filters to narrow results rather than paying for
+  broader searches and filtering client side.


### PR DESCRIPTION
Adds two You.com providers to the registry. You.com launched x402 machine payments on these APIs on August 4, 2026, and this PR follows up on the pay.sh intake submission.

## Providers

**you-com/search** (category: search)
- `GET /v1/search` at $0.005 per call, quoted in USDC on Solana mainnet and Base
- Optional `livecrawl` adds $0.001 per result, priced into the 402 quote
- Inline endpoints with a pricing block, spend-aware usage notes included

**you-com/finance-research** (category: finance)
- `POST /v1/finance_research` at $0.11 (deep) or $0.50 (exhaustive) per call
- Async flow: paying returns a jobId, result is fetched from the SIWX-authed poll_url

## Notes for reviewers

- Both endpoints were probed live and return HTTP 402 with x402 V2 challenges advertising Solana mainnet USDC (`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`, mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`), plus Base USDC and MPP terms in the same response.
- `POST /v1/finance_research` issues the 402 before body validation, so the empty-body CI probe receives a valid challenge (verified).
- `/v1/agents/search` also accepts x402 on GET and POST, but it is intentionally not listed as a paid endpoint: unauthenticated requests without a payment header are served by a free tier and return 200, which would not satisfy the 402 probe. It is documented in the PAY.md prose instead.
- Docs: https://you.com/docs/administration/machine-payments/x402

Submitted by the PM who owns this product area at You.com.