### PR TITLE
Add Microsoft Release Impact agent

### DIFF
--- a/providers/microsoft/release-impact/PAY.md
+++ b/providers/microsoft/release-impact/PAY.md
@@ -1,0 +1,12 @@
+---
+name: release-impact
+title: "Microsoft Release Impact Agent"
+description: "Answers questions about recent Azure changes and release impact."
+use_case: "Use when an agent needs up-to-date knowledge on Microsoft/Azure releases."
+category: devtools
+service_url: "https://microsoft-release-impact-pay.sumitg3767.workers.dev"
+openapi:
+  path: openapi.json
+---
+## Spend-aware usage
+- Ask specific questions about a particular service rather than broad queries.

--- a/providers/microsoft/release-impact/PAY.md
+++ b/providers/microsoft/release-impact/PAY.md
@@ -1,12 +1,16 @@
 ---
 name: release-impact
 title: "Microsoft Release Impact Agent"
-description: "Answers questions about recent Azure changes and release impact."
-use_case: "Use when an agent needs up-to-date knowledge on Microsoft/Azure releases."
+description: "Answers questions about recent Azure changes, Microsoft release notes, breaking changes, and service updates."
+use_case: "Use when an agent needs up-to-date knowledge on Microsoft/Azure releases, API deprecations, infrastructure changes, or service migrations."
 category: devtools
 service_url: "https://microsoft-release-impact-pay.sumitg3767.workers.dev"
 openapi:
   path: openapi.json
 ---
 ## Spend-aware usage
-- Ask specific questions about a particular service rather than broad queries.
+
+- This provider queries an agent augmented with current Microsoft/Azure release data. Each query incurs a small microcents cost.
+- Be specific in your queries. Ask about a particular service (e.g., "What are the recent breaking changes in Azure Cosmos DB?") rather than broad questions ("What changed in Azure?").
+- The response includes structured release-impact results containing summaries, matched changes, actionable steps, and source links. Use the source links to fetch primary documentation instead of issuing another paid query.
+- Combine multiple related service inquiries into a single query to reduce round-trip costs.

--- a/providers/microsoft/release-impact/openapi.json
+++ b/providers/microsoft/release-impact/openapi.json
@@ -1,0 +1,84 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Microsoft Release Impact Agent",
+    "description": "Answers questions about recent Azure changes.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://microsoft-release-impact-pay.sumitg3767.workers.dev"
+    }
+  ],
+  "paths": {
+    "/agent": {
+      "post": {
+        "summary": "Search Microsoft Azure release impact",
+        "description": "Ask a question about recent Azure changes.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "task": {
+                    "type": "string",
+                    "description": "The question or task to ask the agent."
+                  }
+                },
+                "required": ["task"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "summary": { "type": "string" },
+                        "totalMatches": { "type": "integer" },
+                        "relevantMatches": { "type": "integer" },
+                        "changes": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "title": { "type": "string" },
+                              "product": { "type": "string" },
+                              "status": { "type": "string" },
+                              "date": { "type": "string" },
+                              "description": { "type": "string" }
+                            }
+                          }
+                        },
+                        "actions": {
+                          "type": "array",
+                          "items": { "type": "string" }
+                        },
+                        "sources": {
+                          "type": "array",
+                          "items": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a paid Microsoft Release Impact agent that provides
up-to-date Azure/Microsoft release information.

The agent is deployed on Cloudflare Workers and protected
by Solana MPP with a $0.01 USDC charge per request.

Catalog validation passes with pay catalog check.