### PR TITLE
providers: add metagraphed/bittensor

### DIFF
--- a/providers/metagraphed/bittensor/PAY.md
+++ b/providers/metagraphed/bittensor/PAY.md
@@ -1,0 +1,84 @@
+---
+name: bittensor
+title: "metagraphed"
+description: "Bittensor subnet registry and chain data: per-subnet profiles, the API surfaces each subnet publishes with probe-derived health and uptime, emissions, yield and validator economics, hotkey and coldkey balances, stake positions, blocks and extrinsics."
+use_case: "Use for Bittensor and TAO questions: which subnet does a given task, how to call a subnet's own API, whether an endpoint is up, comparing emissions, yield or validator economics, and looking up wallet balances, stake positions and registrations."
+category: data
+service_url: https://api.metagraph.sh
+openapi:
+  path: openapi.json
+---
+
+metagraphed is an independent operational and integration registry for
+[Bittensor](https://bittensor.com). It answers two kinds of question a chain
+explorer does not: **what does each subnet actually expose**, and **is it
+working right now**.
+
+Every subnet in the registry carries its published surfaces — REST APIs, docs,
+schemas, dashboards — each with a `source_url` proving the subnet publishes it,
+and each probed on a schedule so health, uptime and latency are measured rather
+than asserted. Alongside that sits the chain itself: blocks, extrinsics,
+balances, stake positions, emissions, yield and validator economics.
+
+## What an agent reaches for
+
+- `GET /api/v1/subnets` and `GET /api/v1/subnets/{netuid}` — the registry, and
+  one subnet's full profile.
+- `GET /api/v1/search` and `GET /api/v1/search/semantic` — find a subnet by
+  keyword, or by what you are trying to do.
+- `POST /api/v1/ask` — a grounded natural-language answer with citations back
+  to the records it used.
+- `GET /api/v1/subnets/{netuid}/surfaces` and `/endpoints` — what a subnet
+  publishes and how to call it, which is the step before integrating with it.
+- `GET /api/v1/subnets/{netuid}/health` — probe-derived, never hand-set.
+- `GET /api/v1/accounts/{ss58}` — balances, stake and registrations for a
+  hotkey or coldkey.
+
+## Freshness and honesty
+
+Readings carry provenance and a timestamp. Where a projection cannot answer
+within its scan budget the response says so with an explicit reason code rather
+than returning a plausible-looking empty result — an absent answer and a zero
+are different answers, and the API distinguishes them.
+
+Health, uptime and latency are derived from scheduled probes only. No figure on
+this surface is set by hand.
+
+## Payment
+
+There are two tiers, and the line between them is deliberate.
+
+**Free, and staying free.** The whole registry, discovery, health, schema and
+economics layer, plus `ask` and semantic search. No account, no key, no
+payment header. These are served anonymously — this API's own website calls
+them that way — and presenting a payment on one buys extra rate and quota
+headroom rather than access. A request with no payment header is never
+refused.
+
+**Paid.** `GET /api/v1/export/chain-events` answers `402` with an x402 quote
+when no payment is presented. It returns up to 25,000 chain events in one
+call, against the free `/api/v1/chain-events` route's 100 — the same rows,
+filters and ordering, without the page ceiling or the cursor bookkeeping. It
+is the only route on this API that requires payment, and it exists because a
+single unpaginated pass over the lakehouse is the shape that costs real money
+to serve.
+
+x402 v2, `exact` scheme, settled through the public facilitator. Every quote
+lists a Solana (USDC) leg and a Base leg, so pay with whichever you hold.
+`GET /.well-known/x402` states what is payable, on which networks, and to
+which address.
+
+## Spend-aware usage
+
+- Start from `search` or `search/semantic` to find the netuid, then fetch that
+  one subnet. Listing the whole registry to find one row is the expensive way
+  to ask a cheap question.
+- `ask` is the costly call — it runs retrieval and a model. Prefer it when you
+  need a synthesised answer with citations, not when a single field would do.
+- Most artifacts are edge-cached and carry validators. Honouring them costs you
+  nothing and costs the service less.
+- Block and extrinsic reads take explicit ranges. Bound them; an unbounded
+  range scans far more than it returns.
+- Page the free `/api/v1/chain-events` when you need tens of rows. Reach for
+  the paid export when you need thousands — one priced call beats 250 free
+  ones for you and for us.

--- a/providers/metagraphed/bittensor/openapi.json
+++ b/providers/metagraphed/bittensor/openapi.json
@@ -2955,6 +2955,215 @@
         ]
       }
     },
+    "/api/v1/chain-events": {
+      "get": {
+        "description": "Fetch the recent all-events feed (newest first) from the chain_events lakehouse table — every raw pallet.method event, distinct from the curated account-attributed stream. ?pallet / ?method narrow by event id (1-64 ASCII identifier chars); ?block (+ optional ?extrinsic) scopes to one block or extrinsic; ?cursor is the lossless block_number.event_index keyset cursor and ?before is the legacy block_number-only cursor; ?limit caps the page (<=100, default 50). Pass ?format=csv to download the page as CSV. Each page reads one bounded block window below its ceiling, so a short page still carries a continuation rather than ending the feed. Served live, no static file.",
+        "operationId": "chainEventsFeed",
+        "parameters": [
+          {
+            "description": "Filter to events emitted by this pallet, e.g. `SubtensorModule` or `Balances`.",
+            "in": "query",
+            "name": "pallet",
+            "required": false,
+            "schema": {
+              "maxLength": 64,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter to events with this method name within the pallet, e.g. `StakeAdded`.",
+            "in": "query",
+            "name": "method",
+            "required": false,
+            "schema": {
+              "maxLength": 64,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+            "in": "query",
+            "name": "block",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter to events emitted by the extrinsic at this index within its block.",
+            "in": "query",
+            "name": "extrinsic",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque pagination token: pass back the `next_cursor` from the previous response verbatim. Its contents are not stable and must not be parsed or constructed. Stable across inserts, unlike a row offset.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "description": "Opaque block_number.event_index cursor returned as next_cursor; both parts are non-negative safe integers.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+            "in": "query",
+            "name": "before",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 100). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 50.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "ChainEventsFeedArtifactResponse": {
+                    "$ref": "#/components/examples/ChainEventsFeedArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/ChainEventsFeedArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "text/csv": {
+                "examples": {
+                  "ChainEventsFeedCsv": {
+                    "$ref": "#/components/examples/ChainEventsFeedCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "List recent chain events",
+        "tags": [
+          "chain",
+          "analytics"
+        ],
+        "x-metagraphed-networks": [
+          "finney",
+          "mainnet",
+          "test",
+          "testnet"
+        ]
+      }
+    },
     "/api/v1/export/chain-events": {
       "get": {
         "description": "Fetch up to 25,000 chain events in one call -- the same rows, filters and ordering as /api/v1/chain-events, without the 100-row page ceiling or the cursor bookkeeping that comes with it. ?pallet / ?method narrow by event id; ?before reads down from a block number, which is how a caller walks a large range in deliberate chunks; ?limit caps the call (<=25000, default 5000). REQUIRES PAYMENT: this route answers 402 with an x402 quote when no payment is presented, on Base or Solana -- see /.well-known/x402. It is the one family that does; every other route on this API serves an unpaid caller normally. Served live, no static file.",
@@ -3064,7 +3273,7 @@
                 }
               }
             },
-            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+            "description": "Payment is required for this route. An unpaid request receives this 402 response with an x402 quote in the `accepts` array and `PAYMENT-REQUIRED` header; a payment that cannot be verified or settled also returns 402 with a fresh quote."
           },
           "404": {
             "content": {

--- a/providers/metagraphed/bittensor/openapi.json
+++ b/providers/metagraphed/bittensor/openapi.json
@@ -1,0 +1,10352 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "description": "Public, read-only API over canonical Metagraphed registry artifacts for Bittensor subnet interfaces. **No authentication** — every operation is an unauthenticated GET. Responses use a stable JSON envelope `{ ok, schema_version, data, meta }` (errors: `{ ok: false, error }`) and carry `ETag` + `Cache-Control` for conditional caching. Rate-limited per client. Multi-network: insert a `/{network}/` segment after `/api/v1/` (mainnet is the default — omit it) to read testnet data, e.g. `/api/v1/testnet/subnets`. Testnet exposes the subset of routes that have data; `/api/v1/lineage` tracks which testnet subnets have graduated.",
+    "title": "Metagraphed API",
+    "version": "2026-07-03.2"
+  },
+  "servers": [
+    {
+      "description": "Production (mainnet default; insert /testnet/ after /api/v1/ for testnet data)",
+      "url": "https://api.metagraph.sh"
+    }
+  ],
+  "paths": {
+    "/api/v1/subnets": {
+      "get": {
+        "description": "List active Finney subnets. The screening fields ride the `fields=` projection: `gpu_required`/`min_vram_gb` are the MINER hardware floor from the subnet's own min_compute.yml (four-valued -- `required`, `not-required`, `declared-inconsistently`, and null for the subnets whose repo publishes no readable file -- a null is NOT a no), and `also_on` names the testnet twin. The whole declaration, both roles and the commit it was read at, is the `compute_requirements` section on /subnets/{netuid}/overview.",
+        "operationId": "subnets",
+        "parameters": [
+          {
+            "description": "Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's.",
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Comma-separated subnet ids to restrict the result to, e.g. `1,7,64`. At most 128 ids, each 0-65535. Unknown ids match nothing rather than erroring.",
+            "in": "query",
+            "name": "netuids",
+            "required": false,
+            "schema": {
+              "maxLength": 767,
+              "pattern": "^\\d{1,5}(,\\d{1,5}){0,127}$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "coverage_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "curation_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "community-seeded",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "domain",
+            "required": false,
+            "schema": {
+              "enum": [
+                "agents",
+                "compute",
+                "data",
+                "finance",
+                "inference",
+                "media",
+                "prediction",
+                "privacy",
+                "robotics",
+                "science",
+                "search",
+                "security",
+                "storage",
+                "training"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "active",
+                "inactive"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "subnet_type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "root",
+                "application"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "maxLength": 200,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_block",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_block",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_candidate_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_candidate_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_integration_readiness",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_integration_readiness",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_mechanism_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_mechanism_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_participant_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_participant_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_probed_surface_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_probed_surface_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_surface_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_surface_count",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_tempo",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_tempo",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "block",
+                "candidate_count",
+                "coverage_level",
+                "curation_level",
+                "integration_readiness",
+                "mechanism_count",
+                "name",
+                "netuid",
+                "participant_count",
+                "probed_surface_count",
+                "status",
+                "subnet_type",
+                "surface_count",
+                "tempo"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "SubnetsArtifactResponse": {
+                    "$ref": "#/components/examples/SubnetsArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SubnetsArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "text/csv": {
+                "examples": {
+                  "CandidatesCsv": {
+                    "$ref": "#/components/examples/CandidatesCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "List active Finney subnets",
+        "tags": [
+          "subnets"
+        ],
+        "x-metagraphed-networks": [
+          "finney",
+          "mainnet",
+          "test",
+          "testnet"
+        ]
+      }
+    },
+    "/api/v1/subnets/{netuid}": {
+      "get": {
+        "description": "Fetch per-subnet detail.",
+        "operationId": "subnetDetail",
+        "parameters": [
+          {
+            "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
+            "in": "path",
+            "name": "netuid",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "in": "query",
+            "name": "sections",
+            "required": false,
+            "schema": {
+              "pattern": "^(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces)(?:,(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces))*$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "SubnetDetailArtifactResponse": {
+                    "$ref": "#/components/examples/SubnetDetailArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SubnetDetailArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch one subnet's full profile",
+        "tags": [
+          "subnets"
+        ],
+        "x-metagraphed-networks": [
+          "finney",
+          "mainnet",
+          "test",
+          "testnet"
+        ]
+      }
+    },
+    "/api/v1/subnets/{netuid}/health": {
+      "get": {
+        "description": "Fetch health detail for one subnet.",
+        "operationId": "subnetHealth",
+        "parameters": [
+          {
+            "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
+            "in": "path",
+            "name": "netuid",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "classification",
+            "required": false,
+            "schema": {
+              "enum": [
+                "auth-required",
+                "content-mismatch",
+                "dead",
+                "live",
+                "rate-limited",
+                "redirected",
+                "timeout",
+                "transient",
+                "unsupported",
+                "unsafe",
+                "wrong-chain"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "classification",
+                "kind",
+                "last_checked",
+                "last_ok",
+                "latency_ms",
+                "netuid",
+                "provider",
+                "status",
+                "status_code",
+                "surface_id",
+                "verified_at"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "HealthSubnetArtifactResponse": {
+                    "$ref": "#/components/examples/HealthSubnetArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/HealthSubnetArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch probe-derived health for one subnet",
+        "tags": [
+          "health",
+          "subnets"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/subnets/{netuid}/surfaces": {
+      "get": {
+        "description": "List curated public surfaces for one subnet.",
+        "operationId": "subnetSurfaces",
+        "parameters": [
+          {
+            "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
+            "in": "path",
+            "name": "netuid",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "auth_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "public_safe",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rate_limited",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "id",
+                "kind",
+                "name",
+                "netuid",
+                "provider"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "SubnetSurfacesArtifactResponse": {
+                    "$ref": "#/components/examples/SubnetSurfacesArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SubnetSurfacesArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "text/csv": {
+                "examples": {
+                  "CandidatesCsv": {
+                    "$ref": "#/components/examples/CandidatesCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "List the API surfaces one subnet publishes",
+        "tags": [
+          "surfaces",
+          "subnets"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/subnets/{netuid}/endpoints": {
+      "get": {
+        "description": "List generalized endpoint resources for one subnet.",
+        "operationId": "subnetEndpoints",
+        "parameters": [
+          {
+            "description": "The subnet's numeric id on the Bittensor network, as used by the chain itself.",
+            "example": 1,
+            "in": "path",
+            "name": "netuid",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "layer",
+            "required": false,
+            "schema": {
+              "enum": [
+                "bittensor-base",
+                "data-provider",
+                "docs-provider",
+                "subnet-app"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "pool_eligible",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "publication_state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "candidate",
+                "verified",
+                "monitored",
+                "pool-eligible",
+                "disabled",
+                "rejected"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_latency_ms",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_latency_ms",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive lower bound: only rows at or above this value are returned.",
+            "in": "query",
+            "name": "min_score",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Inclusive upper bound: only rows at or below this value are returned.",
+            "in": "query",
+            "name": "max_score",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "kind",
+                "last_checked",
+                "latency_ms",
+                "layer",
+                "netuid",
+                "pool_eligible",
+                "provider",
+                "publication_state",
+                "score",
+                "status"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "SubnetEndpointsArtifactResponse": {
+                    "$ref": "#/components/examples/SubnetEndpointsArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SubnetEndpointsArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "text/csv": {
+                "examples": {
+                  "CandidatesCsv": {
+                    "$ref": "#/components/examples/CandidatesCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "List live endpoints for one subnet, with probe results",
+        "tags": [
+          "endpoints",
+          "subnets"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/search": {
+      "get": {
+        "description": "Fetch compact search index.",
+        "operationId": "search",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "subnet",
+                "surface",
+                "provider"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's.",
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "maxLength": 200,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "netuid",
+                "slug",
+                "title",
+                "type"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "SearchArtifactResponse": {
+                    "$ref": "#/components/examples/SearchArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SearchArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Search the registry by keyword",
+        "tags": [
+          "search"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/search/semantic": {
+      "get": {
+        "description": "Search the registry by MEANING rather than by keyword: ?q= is embedded and ranked by cosine similarity, so it finds surfaces whose text never contains your terms. The complement to /api/v1/search, which is lexical -- reach for that one when you know the exact name. Each result carries its score, type, netuid/slug, title/subtitle, URL, categories, and service kinds; `model` names the embedding model. ?limit caps the list. Mirrored by the `semantic_search` MCP tool. Served live (no static file); 503 ai_unavailable where no AI binding is configured.",
+        "operationId": "searchSemantic",
+        "parameters": [
+          {
+            "description": "Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing.",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "maxLength": 1000,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 20). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 10.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 20,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "enum": [
+                "subnet",
+                "surface",
+                "provider"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "SemanticSearchArtifactResponse": {
+                    "$ref": "#/components/examples/SemanticSearchArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SemanticSearchArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Search the registry by meaning, not keyword",
+        "tags": [
+          "search"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/ask": {
+      "post": {
+        "description": "Ask a natural-language question about the registry and get a grounded answer with citations. POST a JSON body `{ question }`; the answer carries inline [n] markers resolved by `citations`, each naming the surface it came from, so every claim is traceable to a registered surface rather than to the model. Use this when the question is exploratory (\"which subnets expose a public inference API?\"); use /api/v1/search/semantic when you want the ranked matches themselves rather than prose. Mirrored by the `ask` MCP tool. Served live (no static file); 503 ai_unavailable where no AI binding is configured.",
+        "operationId": "ask",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AskRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "AskArtifactResponse": {
+                    "$ref": "#/components/examples/AskArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AskArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Generate a grounded answer with citations",
+        "tags": [
+          "search"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/surfaces": {
+      "get": {
+        "description": "List curated public surfaces.",
+        "operationId": "surfaces",
+        "parameters": [
+          {
+            "description": "Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's.",
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Restrict the result to rows whose field equals this value. Matched exactly (case-insensitively), not searched for as a substring — an unmatched value yields an empty result rather than an error.",
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "maxLength": 100,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "auth_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "public_safe",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "rate_limited",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "id",
+                "kind",
+                "name",
+                "netuid",
+                "provider"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "SurfacesArtifactResponse": {
+                    "$ref": "#/components/examples/SurfacesArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/SurfacesArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "text/csv": {
+                "examples": {
+                  "CandidatesCsv": {
+                    "$ref": "#/components/examples/CandidatesCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "List every published surface across the registry",
+        "tags": [
+          "surfaces"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/coverage": {
+      "get": {
+        "description": "Fetch registry coverage summary.",
+        "operationId": "coverage",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "CoverageArtifactResponse": {
+                    "$ref": "#/components/examples/CoverageArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/CoverageArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch the registry coverage and completeness summary",
+        "tags": [
+          "registry"
+        ],
+        "x-metagraphed-networks": [
+          "finney",
+          "mainnet",
+          "test",
+          "testnet"
+        ]
+      }
+    },
+    "/api/v1/economics": {
+      "get": {
+        "description": "List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, alpha market-cap proxy, alpha FDV proxy, emission share, and registration block height). Default order is emission share descending — note that `emission_share` is the STAGE-1 PRICE SHARE of the v440 emission pipeline (alpha_price / sum of alpha_price), NOT the share of TAO a subnet receives: spec 440 separates the two by MinerBurned reweighting, the Hill emission gate, the SubnetEmissionEnabled filter, the alpha injection cap, and the liquidity balancer. See /api/v1/network/parameters for the gate parameters and docs/computed-metrics-methodology.md for the eight-stage decomposition. Filter by netuid/registration_allowed, search by name/slug, and sort with `sort=<field>&order=asc|desc` — the two are separate parameters (e.g. `?sort=alpha_market_cap_tao&order=desc` or `?sort=block&order=asc`), NOT a combined `field:desc` token. Per-subnet recipient-class economics (who the emission actually goes to -- validators, miners, the burn sink, in alpha and derived USD per day) are NOT here: /subnets/{netuid}/emission-split/history measures that split per day; never reconstruct it from an assumed constant. Registry screening signals (repo health via github_commits_weekly/github_last_push_at, testnet lineage via also_on, the declared miner hardware floor via gpu_required/min_vram_gb) are also NOT here: /api/v1/subnets serves them in bulk behind its fields= projection, e.g. ?fields=netuid,github_commits_weekly,also_on,gpu_required.",
+        "operationId": "economics",
+        "parameters": [
+          {
+            "description": "Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's.",
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "registration_allowed",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Free-text search query, matched case-insensitively against the collection's indexed text fields. Whitespace-separated terms narrow the result (AND), and an empty or whitespace-only value is treated as no filter rather than as a search matching nothing.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "maxLength": 200,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "alpha_fdv_tao",
+                "alpha_market_cap_tao",
+                "alpha_price_change_1d",
+                "alpha_price_change_1h",
+                "alpha_price_change_1m",
+                "alpha_price_change_7d",
+                "alpha_price_tao",
+                "block",
+                "emission_share",
+                "max_stake_alpha",
+                "max_uids",
+                "max_validators",
+                "miner_count",
+                "miner_readiness",
+                "name",
+                "netuid",
+                "open_slots",
+                "registration_cost_tao",
+                "subnet_volume_tao",
+                "total_stake_alpha",
+                "validator_count"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "EconomicsArtifactResponse": {
+                    "$ref": "#/components/examples/EconomicsArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/EconomicsArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "text/csv": {
+                "examples": {
+                  "CandidatesCsv": {
+                    "$ref": "#/components/examples/CandidatesCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "List per-subnet validator and economic metrics",
+        "tags": [
+          "subnets"
+        ],
+        "x-metagraphed-networks": [
+          "finney",
+          "mainnet",
+          "test",
+          "testnet"
+        ]
+      }
+    },
+    "/api/v1/validators": {
+      "get": {
+        "description": "Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows. Sort by subnet_count (default), uid_count, avg_validator_trust, max_validator_trust, total_stake, total_emission, or stake_dominance; limit caps the list (default 20, max 2000). Computed live from the neurons store.",
+        "operationId": "globalValidators",
+        "parameters": [
+          {
+            "description": "Column to rank the result by; pair with `order` for direction. Options are per-tool; see this parameter's enum. Defaults to subnet_count.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "subnet_count",
+              "enum": [
+                "avg_validator_trust",
+                "max_validator_trust",
+                "stake_dominance",
+                "subnet_count",
+                "total_emission",
+                "total_stake",
+                "uid_count"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 2000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 20.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "default": "json",
+              "enum": [
+                "json",
+                "csv"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "GlobalValidatorsArtifactResponse": {
+                    "$ref": "#/components/examples/GlobalValidatorsArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/GlobalValidatorsArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "text/csv": {
+                "examples": {
+                  "GlobalValidatorsCsv": {
+                    "$ref": "#/components/examples/GlobalValidatorsCsv"
+                  }
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch the network-wide validator leaderboard",
+        "tags": [
+          "validators",
+          "analytics"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/accounts/{ss58}": {
+      "get": {
+        "description": "Fetch a cross-subnet activity summary for one account (hotkey or coldkey): chain-event aggregates joined to its current subnet registrations + stake. Computed live from the account_events lakehouse and the neurons tier -- the same rows /accounts/{ss58}/events and /accounts/{ss58}/subnets serve, so the three cannot disagree. A tier that exists and cannot answer declines with a typed 503 (account_summary_unavailable) rather than an all-zero card, which is indistinguishable from an account with no history.",
+        "operationId": "accountSummary",
+        "parameters": [
+          {
+            "description": "An SS58-encoded account address -- a hotkey or coldkey.",
+            "example": "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3",
+            "in": "path",
+            "name": "ss58",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "AccountSummaryArtifactResponse": {
+                    "$ref": "#/components/examples/AccountSummaryArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/AccountSummaryArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch a cross-subnet activity summary for one account",
+        "tags": [
+          "accounts",
+          "analytics"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/health": {
+      "get": {
+        "description": "Fetch global health summary.",
+        "operationId": "health",
+        "parameters": [
+          {
+            "description": "Subnet id (netuid). `0` is the root subnet -- a stake-allocation construct rather than a running subnet. It IS present in the registry collections, but it is excluded from application-subnet counts, and stake on it is denominated in TAO rather than in a subnet alpha token, so its economics are not directly comparable to a running subnet's.",
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "maximum": 65535,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "avg_latency_ms",
+                "degraded_count",
+                "failed_count",
+                "last_checked",
+                "last_ok",
+                "name",
+                "netuid",
+                "ok_count",
+                "status",
+                "surface_count",
+                "unknown_count"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "HealthSummaryArtifactResponse": {
+                    "$ref": "#/components/examples/HealthSummaryArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/HealthSummaryArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch aggregate health across all probed surfaces",
+        "tags": [
+          "health"
+        ],
+        "x-metagraphed-mainnet-only": true,
+        "x-metagraphed-networks": [
+          "mainnet"
+        ]
+      }
+    },
+    "/api/v1/export/chain-events": {
+      "get": {
+        "description": "Fetch up to 25,000 chain events in one call -- the same rows, filters and ordering as /api/v1/chain-events, without the 100-row page ceiling or the cursor bookkeeping that comes with it. ?pallet / ?method narrow by event id; ?before reads down from a block number, which is how a caller walks a large range in deliberate chunks; ?limit caps the call (<=25000, default 5000). REQUIRES PAYMENT: this route answers 402 with an x402 quote when no payment is presented, on Base or Solana -- see /.well-known/x402. It is the one family that does; every other route on this API serves an unpaid caller normally. Served live, no static file.",
+        "operationId": "exportChainEvents",
+        "parameters": [
+          {
+            "description": "Filter to events emitted by this pallet, e.g. `SubtensorModule` or `Balances`.",
+            "in": "query",
+            "name": "pallet",
+            "required": false,
+            "schema": {
+              "maxLength": 64,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter to events with this method name within the pallet, e.g. `StakeAdded`.",
+            "in": "query",
+            "name": "method",
+            "required": false,
+            "schema": {
+              "maxLength": 64,
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+            "in": "query",
+            "name": "before",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 25000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, the server applies 5000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 5000,
+              "maximum": 25000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "ChainEventsFeedArtifactResponse": {
+                    "$ref": "#/components/examples/ChainEventsFeedArtifactResponse"
+                  }
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/ChainEventsFeedArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "A payment was presented and could not be verified or settled. The response carries a fresh x402 quote in the `accepts` array and the PAYMENT-REQUIRED header. A request with NO payment is never answered with 402 -- it is served on the anonymous tier."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch up to 25,000 chain events in one paid call",
+        "tags": [
+          "chain",
+          "analytics"
+        ],
+        "x-metagraphed-networks": [
+          "finney",
+          "mainnet",
+          "test",
+          "testnet"
+        ]
+      }
+    }
+  },
+  "components": {
+    "examples": {
+      "SubnetsArtifactResponse": {
+        "value": {
+          "data": {
+            "captured_at": "2026-06-01T00:00:00.000Z",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+            "network": "finney",
+            "notes": "Example description.",
+            "schema_version": 1,
+            "source": {
+              "identity_storage": "example",
+              "kind": "example",
+              "method": "GET",
+              "package": "example",
+              "rpc_family": "example",
+              "version": "2026-06-29.1"
+            },
+            "subnets": [
+              {
+                "coverage_level": "native-only",
+                "curation_level": "native",
+                "name": "Example Subnet",
+                "netuid": 7,
+                "slug": "example-subnet",
+                "status": "active",
+                "subnet_type": "root",
+                "surface_count": 1
+              }
+            ]
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "CandidatesCsv": {
+        "value": "netuid,name\r\n7,Allways"
+      },
+      "SubnetDetailArtifactResponse": {
+        "value": {
+          "data": {
+            "candidate_surfaces": [
+              {
+                "auth_required": true,
+                "id": "example",
+                "kind": "archive",
+                "name": "Example Subnet",
+                "netuid": 7,
+                "provider": "example-provider",
+                "public_safe": true,
+                "schema_version": 1,
+                "source_url": "https://api.metagraph.sh/example",
+                "state": "schema-invalid",
+                "url": "https://api.metagraph.sh/example"
+              }
+            ],
+            "candidates": [
+              {
+                "auth_required": true,
+                "id": "example",
+                "kind": "archive",
+                "name": "Example Subnet",
+                "netuid": 7,
+                "provider": "example-provider",
+                "public_safe": true,
+                "schema_version": 1,
+                "source_url": "https://api.metagraph.sh/example",
+                "state": "schema-invalid",
+                "url": "https://api.metagraph.sh/example"
+              }
+            ],
+            "contract_version": "2026-06-29.1",
+            "economics": {
+              "alpha_fdv_tao": 0.5,
+              "alpha_fdv_usd": 0.5,
+              "alpha_in_emission": 0.5,
+              "alpha_in_pool": 0.5,
+              "alpha_market_cap_basis": "total_stake_alpha",
+              "alpha_market_cap_tao": 0.5,
+              "alpha_market_cap_usd": 0.5,
+              "alpha_out_emission": 0.5,
+              "alpha_out_pool": 0.5,
+              "alpha_price_change_1d": 0.5,
+              "alpha_price_change_1h": 0.5,
+              "alpha_price_change_1m": 0.5,
+              "alpha_price_change_7d": 0.5,
+              "alpha_price_tao": 0.5,
+              "alpha_price_usd": 0.5,
+              "block": 5000000,
+              "emission_enabled": false,
+              "emission_share": 0.5,
+              "excess_tao": 0.5,
+              "first_emission_block": 5000000,
+              "max_stake_alpha": 0.5,
+              "max_uids": 1,
+              "max_validators": 1,
+              "miner_burned_fraction": 0.5,
+              "miner_count": 1,
+              "miner_readiness": 1,
+              "moving_price_pinned": 0.5,
+              "name": "Example Subnet",
+              "netuid": 7,
+              "open_slots": 1,
+              "owner_coldkey": "example",
+              "owner_hotkey": "example",
+              "registered_at_block": 5000000,
+              "registration_allowed": false,
+              "registration_allowed_pinned": false,
+              "registration_cost_tao": 0.5,
+              "slug": "example-subnet",
+              "spot_price_tao": 0.5,
+              "subnet_mechanism": 1,
+              "subnet_volume_tao": 0.5,
+              "subtoken_enabled": false,
+              "tao_in_emission_tao": 0.5,
+              "tao_in_pool_tao": 0.5,
+              "total_stake_alpha": 0.5,
+              "validator_count": 1
+            },
+            "endpoints": [
+              {
+                "auth_required": true,
+                "health_source": "probe-derived",
+                "health_stale": false,
+                "id": "example",
+                "kind": "archive",
+                "last_ok": "2026-06-01T00:00:00.000Z",
+                "layer": "bittensor-base",
+                "monitoring_policy": {
+                  "enabled": true,
+                  "expect": "example",
+                  "method": "GET",
+                  "source": "live-cron-prober"
+                },
+                "monitoring_status": "monitored",
+                "netuid": 7,
+                "observed_at": "2026-06-01T00:00:00.000Z",
+                "operator": "example-provider",
+                "pool_eligible": false,
+                "provider": "example-provider",
+                "public_safe": true,
+                "publication_state": "candidate",
+                "score": 100,
+                "status": "ok",
+                "surface_id": "example",
+                "surface_key": "example",
+                "url": "https://api.metagraph.sh/example"
+              }
+            ],
+            "gaps": {
+              "gap_notes": [
+                "example"
+              ],
+              "missing_kinds": [
+                "archive"
+              ],
+              "moving_target_surfaces": [
+                "example"
+              ],
+              "supported_kinds": [
+                "archive"
+              ]
+            },
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "health_source": "probe-derived",
+            "notes": "Example description.",
+            "operational_observed_at": "2026-06-01T00:00:00.000Z",
+            "schema_version": 1,
+            "subnet": {
+              "block": 5000000,
+              "candidate_count": 1,
+              "categories": [
+                "example"
+              ],
+              "contact": "example",
+              "coverage_level": "native-only",
+              "curation": {
+                "level": "native",
+                "review_state": "unreviewed"
+              },
+              "curation_level": "native",
+              "dashboard_url": "https://api.metagraph.sh/example",
+              "derived_categories": [
+                "example"
+              ],
+              "description": "Example description.",
+              "docs_url": "https://api.metagraph.sh/example",
+              "gap_count": 1,
+              "gaps": {
+                "gap_notes": [
+                  "example"
+                ],
+                "missing_kinds": [
+                  "archive"
+                ],
+                "supported_kinds": [
+                  "archive"
+                ]
+              },
+              "github_commits_weekly": [
+                {
+                  "count": 1,
+                  "week": "2026-06-01T00:00:00.000Z"
+                }
+              ],
+              "github_languages": {},
+              "github_last_push_at": "2026-06-01T00:00:00.000Z",
+              "github_releases": [
+                {
+                  "name": "Example Subnet",
+                  "prerelease": false,
+                  "published_at": "2026-06-01T00:00:00.000Z",
+                  "tag": "example",
+                  "url": "https://api.metagraph.sh/example"
+                }
+              ],
+              "github_stars": 1,
+              "github_unreachable": false,
+              "lifecycle": "active",
+              "links": [
+                {
+                  "label": "example",
+                  "url": "https://api.metagraph.sh/example"
+                }
+              ],
+              "logo_url": "https://api.metagraph.sh/example",
+              "mechanism_count": 1,
+              "name": "Example Subnet",
+              "native_name": "example",
+              "native_name_quality": "chain",
+              "native_slug": "example-subnet",
+              "netuid": 7,
+              "notes": "Example description.",
+              "participant_count": 1,
+              "partnership": {
+                "since": "2026-06-01",
+                "tier": "pilot"
+              },
+              "previously_known_as": [
+                "example"
+              ],
+              "probed_surface_count": 1,
+              "provenance": {},
+              "registered_at_block": 5000000,
+              "revenue_search": {
+                "checked": [
+                  "website"
+                ],
+                "outcome": "none-found",
+                "searched_at": "2026-06-01T00:00:00.000Z"
+              },
+              "slug": "example-subnet",
+              "social": {},
+              "source_repo": "https://api.metagraph.sh/example",
+              "status": "active",
+              "subnet_type": "root",
+              "surface_count": 1,
+              "symbol": "example",
+              "tempo": 1,
+              "wallet_search": {
+                "checked": [
+                  "website"
+                ],
+                "outcome": "none-found",
+                "searched_at": "2026-06-01T00:00:00.000Z"
+              },
+              "website_url": "https://api.metagraph.sh/example"
+            },
+            "surfaces": [
+              {
+                "auth_required": true,
+                "authority": "community",
+                "id": "example",
+                "kind": "archive",
+                "netuid": 7,
+                "provider": "example-provider",
+                "public_safe": true,
+                "url": "https://api.metagraph.sh/example"
+              }
+            ],
+            "verified_surfaces": [
+              {
+                "auth_required": true,
+                "authority": "community",
+                "id": "example",
+                "kind": "archive",
+                "netuid": 7,
+                "provider": "example-provider",
+                "public_safe": true,
+                "url": "https://api.metagraph.sh/example"
+              }
+            ]
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "HealthSubnetArtifactResponse": {
+        "value": {
+          "data": {
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "health_source": "probe-derived",
+            "name": "Example Subnet",
+            "netuid": 7,
+            "operational_observed_at": "2026-06-01T00:00:00.000Z",
+            "schema_version": 1,
+            "slug": "example-subnet",
+            "summary": {
+              "avg_latency_ms": 120,
+              "degraded_count": 1,
+              "failed_count": 1,
+              "last_checked": "2026-06-01T00:00:00.000Z",
+              "last_ok": "2026-06-01T00:00:00.000Z",
+              "latency_sample_count": 120,
+              "name": "Example Subnet",
+              "netuid": 7,
+              "ok_count": 1,
+              "slug": "example-subnet",
+              "status": "ok",
+              "surface_count": 1,
+              "unknown_count": 1
+            },
+            "surfaces": [
+              {
+                "kind": "archive",
+                "netuid": 7,
+                "observed_by": "live-cron-prober",
+                "provider": "example-provider",
+                "status": "ok",
+                "surface_id": "example",
+                "url": "https://api.metagraph.sh/example"
+              }
+            ]
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "SubnetSurfacesArtifactResponse": {
+        "value": {
+          "data": {
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "name": "Example Subnet",
+            "netuid": 7,
+            "notes": "Example description.",
+            "schema_version": 1,
+            "slug": "example-subnet",
+            "surfaces": [
+              {
+                "auth_required": true,
+                "authority": "community",
+                "id": "example",
+                "kind": "archive",
+                "netuid": 7,
+                "provider": "example-provider",
+                "public_safe": true,
+                "url": "https://api.metagraph.sh/example"
+              }
+            ]
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "SubnetEndpointsArtifactResponse": {
+        "value": {
+          "data": {
+            "contract_version": "2026-06-29.1",
+            "endpoints": [
+              {
+                "auth_required": true,
+                "health_source": "probe-derived",
+                "health_stale": false,
+                "id": "example",
+                "kind": "archive",
+                "last_ok": "2026-06-01T00:00:00.000Z",
+                "layer": "bittensor-base",
+                "monitoring_policy": {
+                  "enabled": true,
+                  "expect": "example",
+                  "method": "GET",
+                  "source": "live-cron-prober"
+                },
+                "monitoring_status": "monitored",
+                "netuid": 7,
+                "observed_at": "2026-06-01T00:00:00.000Z",
+                "operator": "example-provider",
+                "pool_eligible": false,
+                "provider": "example-provider",
+                "public_safe": true,
+                "publication_state": "candidate",
+                "score": 100,
+                "status": "ok",
+                "surface_id": "example",
+                "surface_key": "example",
+                "url": "https://api.metagraph.sh/example"
+              }
+            ],
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "health_source": "probe-derived",
+            "name": "Example Subnet",
+            "netuid": 7,
+            "notes": "Example description.",
+            "operational_observed_at": "2026-06-01T00:00:00.000Z",
+            "schema_version": 1,
+            "slug": "example-subnet",
+            "summary": {
+              "by_kind": {},
+              "by_layer": {},
+              "by_provider": {},
+              "by_publication_state": {},
+              "by_status": {},
+              "endpoint_count": 1,
+              "monitored_count": 1,
+              "pool_eligible_count": 1
+            }
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "SearchArtifactResponse": {
+        "value": {
+          "data": {
+            "contract_version": "2026-06-29.1",
+            "document_count": 1,
+            "documents": [
+              {
+                "artifact_path": "example",
+                "id": "example",
+                "title": "Example Subnet",
+                "tokens": [
+                  "example"
+                ],
+                "type": "subnet"
+              }
+            ],
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "notes": "Example description.",
+            "schema_version": 1
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "SemanticSearchArtifactResponse": {
+        "value": {
+          "data": {
+            "count": 1,
+            "model": "example",
+            "query": "example",
+            "results": [
+              {
+                "categories": [
+                  "example"
+                ],
+                "netuid": 7,
+                "score": 100,
+                "service_kinds": [
+                  "example"
+                ],
+                "slug": "example-subnet",
+                "title": "Example Subnet",
+                "type": "example"
+              }
+            ]
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "AskArtifactResponse": {
+        "value": {
+          "data": {
+            "answer": "example",
+            "citations": [
+              {
+                "netuid": 7,
+                "ref": 1,
+                "score": 100,
+                "slug": "example-subnet",
+                "title": "Example Subnet",
+                "url": "https://api.metagraph.sh/example"
+              }
+            ],
+            "context_count": 1,
+            "model": "example",
+            "question": "example"
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "SurfacesArtifactResponse": {
+        "value": {
+          "data": {
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "notes": "Example description.",
+            "schema_version": 1,
+            "surfaces": [
+              {
+                "auth_required": true,
+                "authority": "community",
+                "id": "example",
+                "kind": "archive",
+                "netuid": 7,
+                "provider": "example-provider",
+                "public_safe": true,
+                "url": "https://api.metagraph.sh/example"
+              }
+            ]
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "CoverageArtifactResponse": {
+        "value": {
+          "data": {
+            "application_subnet_count": 1,
+            "candidate_count": 1,
+            "candidate_subnet_count": 1,
+            "chain_subnet_count": 1,
+            "completeness": {
+              "average_score": 100,
+              "dimension_coverage": {},
+              "fully_complete_count": 1,
+              "fully_complete_pct": 1,
+              "median_score": 100,
+              "methodology": "GET",
+              "score_distribution": {},
+              "scored_subnet_count": 1
+            },
+            "contract_version": "2026-06-29.1",
+            "curated_overlay_count": 1,
+            "curation_level_counts": {
+              "example": 1
+            },
+            "domain_coverage": {
+              "example": 1
+            },
+            "first_party_subnet_count": 1,
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "manifested_count": 1,
+            "native_only_count": 1,
+            "native_only_with_candidates": 1,
+            "native_only_without_candidates": 1,
+            "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+            "network": "finney",
+            "notes": "Example description.",
+            "official_surface_count": 1,
+            "probed_count": 1,
+            "probed_surface_count": 1,
+            "registry_observed_surface_count": 1,
+            "root_subnet_count": 1,
+            "schema_version": 1,
+            "source": {
+              "candidates": "example",
+              "native": "example",
+              "overlays": "example"
+            },
+            "subnets_without_official_surface": 1,
+            "surface_count": 1
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "EconomicsArtifactResponse": {
+        "value": {
+          "data": {
+            "captured_at": "2026-06-01T00:00:00.000Z",
+            "chain_state": {
+              "block": 5000000,
+              "block_hash": "0xa3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+              "emission_bar_quantile": 0.5,
+              "emission_gate_bar": 0.5,
+              "emission_gate_exponent": 1,
+              "network_immunity_period": 1,
+              "total_issuance_tao": 0.5
+            },
+            "contract_version": "2026-06-29.1",
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "network": "example",
+            "notes": "Example description.",
+            "schema_version": 1,
+            "subnets": [
+              {
+                "alpha_in_pool": 0.5,
+                "alpha_out_pool": 0.5,
+                "alpha_price_tao": 0.5,
+                "max_stake_alpha": 0.5,
+                "max_uids": 1,
+                "max_validators": 1,
+                "miner_count": 1,
+                "owner_coldkey": "example",
+                "owner_hotkey": "example",
+                "registration_allowed": false,
+                "registration_cost_tao": 0.5,
+                "subnet_volume_tao": 0.5,
+                "tao_in_pool_tao": 0.5,
+                "total_stake_alpha": 0.5,
+                "validator_count": 1
+              }
+            ],
+            "summary": {
+              "registration_open_count": 1,
+              "subnet_count": 1,
+              "total_alpha_value_tao": "327838334.635978200",
+              "total_miners": 1,
+              "total_network_value_tao": "327838334.635978200",
+              "total_root_value_tao": "327838334.635978200",
+              "total_stake_alpha": "327838334.635978200",
+              "total_validators": 1,
+              "with_economics_count": 1
+            },
+            "tao_usd": {
+              "block_number": 5000000,
+              "observed_at": "2026-06-01T00:00:00.000Z",
+              "price_basis": "example",
+              "usd_per_tao": 0.5
+            },
+            "tao_usd_unavailable": "no_index_reading"
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "GlobalValidatorsArtifactResponse": {
+        "value": {
+          "data": {
+            "block_number": 5000000,
+            "captured_at": "2026-06-01T00:00:00.000Z",
+            "limit": 1,
+            "schema_version": 1,
+            "sort": "avg_validator_trust",
+            "validator_count": 1,
+            "validators": [
+              {
+                "alpha_stake_tao": 0.5,
+                "apy_estimate": 0.5,
+                "apy_estimate_eligible_subnet_count": 1,
+                "avg_validator_trust": 0.5,
+                "coldkey": "example",
+                "coldkey_count": 1,
+                "coldkey_identity": {
+                  "additional": "example",
+                  "captured_at": "2026-06-01T00:00:00.000Z",
+                  "description": "Example description.",
+                  "discord": "example",
+                  "github": "https://api.metagraph.sh/example",
+                  "has_identity": false,
+                  "image": "https://api.metagraph.sh/example",
+                  "name": "Example Subnet",
+                  "url": "https://api.metagraph.sh/example"
+                },
+                "featured": false,
+                "hotkey": "example",
+                "latest_block_number": 5000000,
+                "latest_captured_at": "2026-06-01T00:00:00.000Z",
+                "max_validator_trust": 0.5,
+                "nominator_count": 1,
+                "realized_return_1d": 0.5,
+                "realized_return_1d_as_of": "example",
+                "realized_return_1m": 0.5,
+                "realized_return_1m_as_of": "example",
+                "realized_return_1w": 0.5,
+                "realized_return_1w_as_of": "example",
+                "root_stake_tao": 0.5,
+                "stake_dominance": 0.5,
+                "subnet_count": 1,
+                "subnets": [
+                  {
+                    "emission_alpha": 0.5,
+                    "netuid": 7,
+                    "stake_alpha": 0.5,
+                    "uid": 1,
+                    "validator_trust": 0.5
+                  }
+                ],
+                "take": 0.5,
+                "total_emission_tao": 0.5,
+                "total_stake_tao": 0.5,
+                "uid_count": 1
+              }
+            ]
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "GlobalValidatorsCsv": {
+        "value": "hotkey,coldkey,coldkey_count,subnet_count,uid_count,total_stake_tao,total_emission_tao,stake_dominance,avg_validator_trust,max_validator_trust,latest_captured_at,latest_block_number,subnets\r\nhk_sample,ck_sample,1,3,3,1234.5,10.25,0.12,0.98,0.99,2026-07-03T00:00:00.000Z,8454388,\"[{\"\"netuid\"\":1,\"\"uid\"\":0}]\""
+      },
+      "AccountSummaryArtifactResponse": {
+        "value": {
+          "data": {
+            "activity": {
+              "last_tx_at": "2026-06-01T00:00:00.000Z",
+              "last_tx_block": 5000000,
+              "modules_called": [
+                {
+                  "call_module": "example",
+                  "count": 1
+                }
+              ],
+              "modules_called_capped": false,
+              "total_fee_tao": 0.5,
+              "tx_count": 1
+            },
+            "event_count": 1,
+            "event_kinds": [
+              {
+                "count": 1,
+                "kind": "example"
+              }
+            ],
+            "event_scan_capped": false,
+            "first_block": 5000000,
+            "first_seen_at": "2026-06-01T00:00:00.000Z",
+            "labels": [
+              {}
+            ],
+            "last_block": 5000000,
+            "last_seen_at": "2026-06-01T00:00:00.000Z",
+            "recent_events": [
+              {
+                "block_number": 5000000,
+                "event_kind": "example"
+              }
+            ],
+            "registrations": [
+              {
+                "active": false,
+                "netuid": 7,
+                "stake_tao": 0.5,
+                "uid": 1,
+                "validator_permit": false
+              }
+            ],
+            "schema_version": 1,
+            "ss58": "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+            "subnet_count": 1
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "HealthSummaryArtifactResponse": {
+        "value": {
+          "data": {
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "global": {
+              "status_counts": {},
+              "surface_count": 1
+            },
+            "health_source": "probe-derived",
+            "operational_observed_at": "2026-06-01T00:00:00.000Z",
+            "schema_version": 1,
+            "scope": "example",
+            "source": "live-cron-prober",
+            "subnets": [
+              {
+                "degraded_count": 1,
+                "failed_count": 1,
+                "ok_count": 1,
+                "status": "ok",
+                "surface_count": 1,
+                "unknown_count": 1
+              }
+            ]
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      },
+      "ChainEventsFeedArtifactResponse": {
+        "value": {
+          "data": {
+            "count": 1,
+            "events": [
+              {
+                "block_number": 5000000,
+                "event_index": 1,
+                "method": "GET",
+                "pallet": "example"
+              }
+            ],
+            "next_before": 1,
+            "next_cursor": "100.123.4"
+          },
+          "meta": {
+            "artifact_path": "example",
+            "cache": "short",
+            "contract_version": "2026-06-29.1",
+            "generated_at": "2026-06-01T00:00:00.000Z",
+            "observed_through": "2026-06-01T00:00:00.000Z",
+            "pagination": {
+              "collection": "example",
+              "cursor": 1,
+              "limit": 1,
+              "next_cursor": 1,
+              "order": "asc",
+              "returned": 1,
+              "sort": "example",
+              "total": 1
+            },
+            "published_at": "2026-06-01T00:00:00.000Z",
+            "source": "live-cron-prober",
+            "stale_contract": {
+              "built_under": "example",
+              "live": "example"
+            }
+          },
+          "ok": true,
+          "schema_version": 1
+        }
+      }
+    },
+    "schemas": {
+      "SuccessEnvelope": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "additionalProperties": {},
+            "properties": {},
+            "type": "object"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          },
+          "ok": {
+            "const": true,
+            "type": "boolean"
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          }
+        },
+        "required": [
+          "ok",
+          "schema_version",
+          "data",
+          "meta"
+        ],
+        "type": "object"
+      },
+      "ResponseMeta": {
+        "additionalProperties": {},
+        "properties": {
+          "artifact_path": {
+            "type": "string"
+          },
+          "cache": {
+            "$ref": "#/components/schemas/CacheProfile"
+          },
+          "contract_version": {
+            "type": "string"
+          },
+          "generated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Deterministic build content marker (epoch by default); not a wall clock. Use published_at for human-facing freshness."
+          },
+          "observed_through": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "How far the tier that answered this request has observed at all. A payload reporting no activity at or before this time is a measured absence; one whose subject is newer is outside coverage, not empty. Null when the horizon is unreadable."
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "published_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Real publish time from the KV latest pointer, distinct from generated_at. Null before the first publish or when the control KV is unbound."
+          },
+          "source": {
+            "type": "string"
+          },
+          "stale_contract": {
+            "additionalProperties": false,
+            "description": "Present ONLY when the served artifact was built under an older contract than the live one (serve-time drift, #1001) — the body may predate a schema change. Mirrored on the x-metagraph-stale-contract response header for monitoring.",
+            "properties": {
+              "built_under": {
+                "description": "Contract version the served artifact was built under.",
+                "type": "string"
+              },
+              "live": {
+                "description": "Current (live) contract version the Worker is running.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "built_under",
+              "live"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "contract_version"
+        ],
+        "type": "object"
+      },
+      "CacheProfile": {
+        "enum": [
+          "short",
+          "standard",
+          "static"
+        ],
+        "type": "string"
+      },
+      "PaginationMeta": {
+        "additionalProperties": false,
+        "properties": {
+          "collection": {
+            "type": "string"
+          },
+          "cursor": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "limit": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "order": {
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          },
+          "returned": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "total": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "collection",
+          "cursor",
+          "limit",
+          "next_cursor",
+          "returned",
+          "total"
+        ],
+        "type": "object"
+      },
+      "SubnetsArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "captured_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the chain snapshot behind this index was captured. Distinct from `generated_at`, which marks the build that shaped it."
+          },
+          "contract_version": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "native_snapshot_captured_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Capture stamp of the native (SDK) snapshot the identity overlay was merged onto."
+          },
+          "network": {
+            "$ref": "#/components/schemas/BittensorNetwork"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          },
+          "source": {
+            "additionalProperties": false,
+            "properties": {
+              "identity_storage": {
+                "type": "string"
+              },
+              "kind": {
+                "type": "string"
+              },
+              "method": {
+                "type": "string"
+              },
+              "package": {
+                "type": "string"
+              },
+              "rpc_family": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "subnets": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetIndexEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "generated_at",
+          "schema_version",
+          "network",
+          "source",
+          "subnets"
+        ],
+        "type": "object"
+      },
+      "BittensorNetwork": {
+        "enum": [
+          "finney",
+          "test",
+          "local"
+        ],
+        "type": "string"
+      },
+      "SubnetIndexEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "also_on": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "matched_by": {
+                      "enum": [
+                        "github_repo",
+                        "chain_name"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "netuid": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "network": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "block": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "candidate_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "contact": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "contact_present": {
+            "type": "boolean"
+          },
+          "coverage_level": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
+            "type": "string"
+          },
+          "curation_level": {
+            "$ref": "#/components/schemas/CurationLevel"
+          },
+          "dashboard_url": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "derived_categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "derived_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "discord": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "discord_url": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "docs_url": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "first_party": {
+            "type": "boolean"
+          },
+          "gap_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "github_commits_weekly": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "week": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "week",
+                    "count"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_languages": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_last_push_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_releases": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "prerelease": {
+                      "type": "boolean"
+                    },
+                    "published_at": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "tag",
+                    "name",
+                    "published_at",
+                    "url",
+                    "prerelease"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_stars": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_unreachable": {
+            "type": "boolean"
+          },
+          "gpu_required": {
+            "anyOf": [
+              {
+                "enum": [
+                  "required",
+                  "not-required",
+                  "declared-inconsistently"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "integration_readiness": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "lifecycle": {
+            "enum": [
+              "active",
+              "deprecated",
+              "parked",
+              "pending"
+            ],
+            "type": "string"
+          },
+          "logo_url": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "mechanism_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "min_vram_gb": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "native_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "native_name_quality": {
+            "enum": [
+              "chain",
+              "placeholder",
+              "empty"
+            ],
+            "type": "string"
+          },
+          "native_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "official_surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "participant_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "partnership": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PartnershipMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "probed_surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "registered_at_block": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "registry_observed_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "social": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SocialLinks"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source_repo": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/SubnetStatus"
+          },
+          "subnet_type": {
+            "$ref": "#/components/schemas/SubnetType"
+          },
+          "surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "symbol": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tempo": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "website_url": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "coverage_level",
+          "curation_level",
+          "name",
+          "netuid",
+          "slug",
+          "status",
+          "subnet_type",
+          "surface_count"
+        ],
+        "type": "object"
+      },
+      "CurationLevel": {
+        "enum": [
+          "native",
+          "candidate-discovered",
+          "community-seeded",
+          "machine-verified",
+          "maintainer-reviewed",
+          "adapter-backed"
+        ],
+        "type": "string"
+      },
+      "PartnershipMetadata": {
+        "additionalProperties": false,
+        "properties": {
+          "since": {
+            "format": "date",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))$",
+            "type": "string"
+          },
+          "tier": {
+            "$ref": "#/components/schemas/PartnershipTier"
+          },
+          "validator_hotkey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "since",
+          "tier"
+        ],
+        "type": "object"
+      },
+      "PartnershipTier": {
+        "description": "Display/placement tier for a subnet — e.g. a featured-pilot homepage slot. Distinct from Authority and CurationLevel, which are trust signals only and never drive placement.",
+        "enum": [
+          "pilot"
+        ],
+        "type": "string"
+      },
+      "SocialLinks": {
+        "additionalProperties": false,
+        "properties": {
+          "reddit": {
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?:\\/\\/",
+            "type": "string"
+          },
+          "telegram": {
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?:\\/\\/",
+            "type": "string"
+          },
+          "x": {
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?:\\/\\/",
+            "type": "string"
+          },
+          "youtube": {
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?:\\/\\/",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SubnetStatus": {
+        "enum": [
+          "active",
+          "inactive",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "SubnetType": {
+        "enum": [
+          "root",
+          "application"
+        ],
+        "type": "string"
+      },
+      "ErrorEnvelope": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "type": "null"
+          },
+          "error": {
+            "additionalProperties": false,
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ],
+            "type": "object"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/ResponseMeta"
+          },
+          "ok": {
+            "const": false,
+            "type": "boolean"
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          }
+        },
+        "required": [
+          "ok",
+          "schema_version",
+          "data",
+          "error",
+          "meta"
+        ],
+        "type": "object"
+      },
+      "SubnetDetailArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "candidate_surfaces": {
+            "items": {
+              "$ref": "#/components/schemas/CandidateSurface"
+            },
+            "type": "array"
+          },
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/CandidateSurface"
+            },
+            "type": "array"
+          },
+          "contract_version": {
+            "type": "string"
+          },
+          "economics": {
+            "$ref": "#/components/schemas/SubnetEconomics"
+          },
+          "endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/EndpointResource"
+            },
+            "type": "array"
+          },
+          "gaps": {
+            "$ref": "#/components/schemas/Gaps"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "health_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Which live tier answered for health on this response. Open-ended: the value comes from the health snapshot's own producer."
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "operational_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp."
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          },
+          "subnet": {
+            "$ref": "#/components/schemas/SubnetDetail"
+          },
+          "surfaces": {
+            "items": {
+              "$ref": "#/components/schemas/Surface"
+            },
+            "type": "array"
+          },
+          "verified_surfaces": {
+            "items": {
+              "$ref": "#/components/schemas/Surface"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "generated_at",
+          "schema_version",
+          "candidate_surfaces",
+          "gaps",
+          "subnet",
+          "surfaces"
+        ],
+        "type": "object"
+      },
+      "CandidateSurface": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/SurfaceAuth"
+          },
+          "auth_required": {
+            "type": "boolean"
+          },
+          "confidence": {
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "type": "string"
+          },
+          "confirmed_by": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/SurfaceKind"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "public_safe": {
+            "type": "boolean"
+          },
+          "rate_limit": {
+            "$ref": "#/components/schemas/SurfaceRateLimit"
+          },
+          "rate_limit_notes": {
+            "type": "string"
+          },
+          "review_notes": {
+            "type": "string"
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          },
+          "source_tier": {
+            "$ref": "#/components/schemas/SourceTier"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "source_url": {
+            "format": "uri",
+            "type": "string"
+          },
+          "source_urls": {
+            "items": {
+              "format": "uri",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "state": {
+            "$ref": "#/components/schemas/CandidateState"
+          },
+          "subnet_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "superseded_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "url": {
+            "format": "uri",
+            "type": "string"
+          },
+          "verification": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VerificationResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "auth_required",
+          "id",
+          "kind",
+          "name",
+          "netuid",
+          "provider",
+          "public_safe",
+          "schema_version",
+          "source_url",
+          "state",
+          "url"
+        ],
+        "type": "object"
+      },
+      "SurfaceAuth": {
+        "anyOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "body_envelope": {
+                "additionalProperties": false,
+                "description": "For scheme:signature with location:body -- which key of the outgoing JSON body carries the credential, and which carries the payload it signs.",
+                "properties": {
+                  "credential_key": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "payload_key": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "credential_key",
+                  "payload_key"
+                ],
+                "type": "object"
+              },
+              "location": {
+                "description": "Where the credential is sent. `body` only applies to scheme:signature, whose values are merged into the outgoing JSON request body.",
+                "enum": [
+                  "header",
+                  "query",
+                  "cookie",
+                  "body"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "The single header the credential goes in.",
+                "type": "string"
+              },
+              "names": {
+                "description": "The header SET, for schemes that need more than one (signature schemes send hotkey + nonce + signature together). Present instead of `name`, not alongside it.",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "scheme": {
+                "description": "`signature` means the request is signed per-call (a hotkey/nonce/signature header set, see `names`), not a static token.",
+                "enum": [
+                  "none",
+                  "bearer",
+                  "api-key",
+                  "basic",
+                  "oauth2",
+                  "signature",
+                  "custom"
+                ],
+                "type": "string"
+              },
+              "scopes_note": {
+                "description": "How the requirement was established -- often a live-checked 401, because a subnet's own OpenAPI frequently declares no securitySchemes at all.",
+                "type": "string"
+              },
+              "token_url": {
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?:\\/\\/",
+                "type": "string"
+              },
+              "value_format": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ],
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "SurfaceKind": {
+        "enum": [
+          "archive",
+          "dashboard",
+          "data-artifact",
+          "docs",
+          "example",
+          "openapi",
+          "repo-registry",
+          "sdk",
+          "source-repo",
+          "sse",
+          "subnet-api",
+          "subtensor-rpc",
+          "subtensor-wss",
+          "website"
+        ],
+        "type": "string"
+      },
+      "SurfaceRateLimit": {
+        "additionalProperties": false,
+        "properties": {
+          "burst": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "cost_notes": {
+            "type": "string"
+          },
+          "requests": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "scope": {
+            "enum": [
+              "per-key",
+              "per-ip",
+              "global",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "window": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "requests",
+          "window"
+        ],
+        "type": "object"
+      },
+      "SourceTier": {
+        "enum": [
+          "native-chain",
+          "provider-claimed",
+          "third-party-index",
+          "community-docs"
+        ],
+        "type": "string"
+      },
+      "CandidateState": {
+        "enum": [
+          "schema-invalid",
+          "schema-valid",
+          "maintainer-review",
+          "verified",
+          "stale",
+          "rejected"
+        ],
+        "type": "string"
+      },
+      "VerificationResult": {
+        "additionalProperties": false,
+        "properties": {
+          "archived": {
+            "type": "boolean"
+          },
+          "candidate_id": {
+            "type": "string"
+          },
+          "classification": {
+            "$ref": "#/components/schemas/Classification"
+          },
+          "confidence_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "default_branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_api_status": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "github_api_url": {
+            "format": "uri",
+            "type": "string"
+          },
+          "homepage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "html_url": {
+            "format": "uri",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/SurfaceKind"
+          },
+          "last_push_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "latency_ms": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "method_tested": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "private_redirect_blocked": {
+            "type": "boolean"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "quality_signals": {
+            "$ref": "#/components/schemas/SurfaceQualitySignals"
+          },
+          "redirect_target": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source_tier": {
+            "$ref": "#/components/schemas/SourceTier"
+          },
+          "source_type": {
+            "type": "string"
+          },
+          "source_url": {
+            "format": "uri",
+            "type": "string"
+          },
+          "source_urls": {
+            "items": {
+              "format": "uri",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/HealthStatus"
+          },
+          "status_code": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "topics": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "url": {
+            "format": "uri",
+            "type": "string"
+          },
+          "verified_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "candidate_id",
+          "classification",
+          "status",
+          "url",
+          "verified_at"
+        ],
+        "type": "object"
+      },
+      "Classification": {
+        "enum": [
+          "live",
+          "redirected",
+          "auth-required",
+          "dead",
+          "unsafe",
+          "unsupported",
+          "rate-limited",
+          "transient",
+          "timeout",
+          "content-mismatch",
+          "wrong-chain",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "SurfaceQualitySignals": {
+        "additionalProperties": false,
+        "properties": {
+          "archived": {
+            "type": "boolean"
+          },
+          "content_type_matches_kind": {
+            "type": "boolean"
+          },
+          "has_default_branch": {
+            "type": "boolean"
+          },
+          "has_recent_push_metadata": {
+            "type": "boolean"
+          },
+          "public_safe": {
+            "type": "boolean"
+          },
+          "rate_limited": {
+            "type": "boolean"
+          },
+          "redirected": {
+            "type": "boolean"
+          },
+          "source_tier": {
+            "$ref": "#/components/schemas/SourceTier"
+          },
+          "transient_failure": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "HealthStatus": {
+        "enum": [
+          "ok",
+          "degraded",
+          "failed",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "SubnetEconomics": {
+        "additionalProperties": false,
+        "properties": {
+          "alpha_fdv_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_fdv_usd": {
+            "description": "alpha_fdv_tao converted at the blob's tao_usd reading.",
+            "type": "number"
+          },
+          "alpha_in_emission": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_in_pool": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_market_cap_basis": {
+            "const": "total_stake_alpha",
+            "description": "What alpha_market_cap_tao multiplies -- published rather than documented, because a market cap without its basis is not a number anyone can reconcile (#10381).",
+            "type": "string"
+          },
+          "alpha_market_cap_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_market_cap_usd": {
+            "description": "alpha_market_cap_tao converted at the blob's tao_usd reading.",
+            "type": "number"
+          },
+          "alpha_out_emission": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_out_pool": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_price_change_1d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227)."
+          },
+          "alpha_price_change_1h": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227)."
+          },
+          "alpha_price_change_1m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227)."
+          },
+          "alpha_price_change_7d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227)."
+          },
+          "alpha_price_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that."
+          },
+          "alpha_price_usd": {
+            "description": "alpha_price_tao converted at the blob's tao_usd reading.",
+            "type": "number"
+          },
+          "block": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "emission_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "emission_share": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "excess_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "first_emission_block": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_stake_alpha": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_uids": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_validators": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "miner_burned_fraction": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "miner_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "miner_readiness": {
+            "anyOf": [
+              {
+                "maximum": 100,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "moving_price_pinned": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "open_slots": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "owner_coldkey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "owner_hotkey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "registered_at_block": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one."
+          },
+          "registration_allowed": {
+            "type": "boolean"
+          },
+          "registration_allowed_pinned": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "registration_cost_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "slug": {
+            "type": "string"
+          },
+          "spot_price_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average."
+          },
+          "subnet_mechanism": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom."
+          },
+          "subnet_volume_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "subtoken_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tao_in_emission_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tao_in_pool_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "total_stake_alpha": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "validator_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "alpha_in_pool",
+          "alpha_out_pool",
+          "alpha_price_tao",
+          "max_stake_alpha",
+          "max_uids",
+          "max_validators",
+          "miner_count",
+          "owner_coldkey",
+          "owner_hotkey",
+          "registration_allowed",
+          "registration_cost_tao",
+          "subnet_volume_tao",
+          "tao_in_pool_tao",
+          "total_stake_alpha",
+          "validator_count"
+        ],
+        "type": "object"
+      },
+      "EndpointResource": {
+        "additionalProperties": false,
+        "properties": {
+          "archive_support": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "auth_required": {
+            "type": "boolean"
+          },
+          "authority": {
+            "$ref": "#/components/schemas/Authority"
+          },
+          "chain": {
+            "const": "bittensor",
+            "type": "string"
+          },
+          "classification": {
+            "$ref": "#/components/schemas/Classification"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "health_source": {
+            "enum": [
+              "probe-derived",
+              "missing-probe",
+              "not-monitored",
+              "live-cron-prober",
+              "unavailable"
+            ],
+            "type": "string"
+          },
+          "health_stale": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/SurfaceKind"
+          },
+          "last_checked": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "last_ok": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "latency_ms": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "latest_block": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "layer": {
+            "$ref": "#/components/schemas/EndpointLayer"
+          },
+          "method_support": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "boolean"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "method_tested": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "monitoring_policy": {
+            "$ref": "#/components/schemas/EndpointMonitoringPolicy"
+          },
+          "monitoring_status": {
+            "enum": [
+              "monitored",
+              "not_monitored"
+            ],
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "network": {
+            "$ref": "#/components/schemas/BittensorNetwork"
+          },
+          "observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "operator": {
+            "type": "string"
+          },
+          "pool_eligibility_reasons": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "pool_eligible": {
+            "type": "boolean"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "public_safe": {
+            "type": "boolean"
+          },
+          "publication_state": {
+            "$ref": "#/components/schemas/EndpointPublicationState"
+          },
+          "rate_limit_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "reliability_grade": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "reliability_score": {
+            "anyOf": [
+              {
+                "maximum": 100,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rpc_method_count": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "score": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "score_reasons": {
+            "items": {
+              "$ref": "#/components/schemas/EndpointScoreReason"
+            },
+            "type": "array"
+          },
+          "source_urls": {
+            "items": {
+              "format": "uri",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/HealthStatus"
+          },
+          "subnet_name": {
+            "type": "string"
+          },
+          "subnet_slug": {
+            "type": "string"
+          },
+          "surface_id": {
+            "type": "string"
+          },
+          "surface_key": {
+            "type": "string"
+          },
+          "url": {
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "auth_required",
+          "health_source",
+          "health_stale",
+          "id",
+          "kind",
+          "last_ok",
+          "layer",
+          "monitoring_policy",
+          "monitoring_status",
+          "netuid",
+          "observed_at",
+          "operator",
+          "pool_eligible",
+          "provider",
+          "public_safe",
+          "publication_state",
+          "score",
+          "status",
+          "surface_id",
+          "surface_key",
+          "url"
+        ],
+        "type": "object"
+      },
+      "Authority": {
+        "enum": [
+          "community",
+          "official",
+          "provider-claimed",
+          "registry-observed"
+        ],
+        "type": "string"
+      },
+      "EndpointLayer": {
+        "enum": [
+          "bittensor-base",
+          "data-provider",
+          "docs-provider",
+          "subnet-app"
+        ],
+        "type": "string"
+      },
+      "EndpointMonitoringPolicy": {
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "expect": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source": {
+            "type": "string"
+          },
+          "timeout_ms": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "enabled",
+          "expect",
+          "method",
+          "source"
+        ],
+        "type": "object"
+      },
+      "EndpointPublicationState": {
+        "enum": [
+          "candidate",
+          "verified",
+          "monitored",
+          "pool-eligible",
+          "disabled",
+          "rejected"
+        ],
+        "type": "string"
+      },
+      "EndpointScoreReason": {
+        "additionalProperties": false,
+        "properties": {
+          "points": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "points",
+          "reason"
+        ],
+        "type": "object"
+      },
+      "Gaps": {
+        "additionalProperties": false,
+        "properties": {
+          "gap_notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "missing_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "moving_target_surfaces": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "supported_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "gap_notes",
+          "missing_kinds",
+          "supported_kinds"
+        ],
+        "type": "object"
+      },
+      "SubnetDetail": {
+        "additionalProperties": false,
+        "properties": {
+          "block": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "candidate_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "contact": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "coverage_level": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
+            "type": "string"
+          },
+          "curation": {
+            "$ref": "#/components/schemas/CurationMetadata"
+          },
+          "curation_level": {
+            "$ref": "#/components/schemas/CurationLevel"
+          },
+          "dashboard_url": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "derived_categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "docs_url": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "gap_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "gaps": {
+            "$ref": "#/components/schemas/Gaps"
+          },
+          "github_commits_weekly": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "week": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "week",
+                    "count"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_languages": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_last_push_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_releases": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "prerelease": {
+                      "type": "boolean"
+                    },
+                    "published_at": {
+                      "format": "date-time",
+                      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "tag",
+                    "name",
+                    "published_at",
+                    "url",
+                    "prerelease"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_stars": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "github_unreachable": {
+            "type": "boolean"
+          },
+          "lifecycle": {
+            "enum": [
+              "active",
+              "deprecated",
+              "parked",
+              "pending"
+            ],
+            "type": "string"
+          },
+          "links": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "source_url": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "label",
+                "url"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "logo_url": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "mechanism_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "native_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "native_name_quality": {
+            "enum": [
+              "chain",
+              "placeholder",
+              "empty"
+            ],
+            "type": "string"
+          },
+          "native_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "participant_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "partnership": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PartnershipMetadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "previously_known_as": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "probed_surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "provenance": {
+            "additionalProperties": false,
+            "properties": {
+              "existence": {
+                "additionalProperties": false,
+                "properties": {
+                  "authority": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "captured_at": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "method": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "network": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "source_kind": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "identity": {
+                "additionalProperties": false,
+                "properties": {
+                  "display_name_source": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "native_name_quality": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "interface_metadata": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "type": "object"
+          },
+          "registered_at_block": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "revenue_search": {
+            "additionalProperties": false,
+            "properties": {
+              "checked": {
+                "description": "Where the search actually looked. Without it, \"we searched\" is unfalsifiable and nobody else can re-run it.",
+                "items": {
+                  "enum": [
+                    "website",
+                    "docs",
+                    "openapi",
+                    "dashboard",
+                    "source-repo",
+                    "blog",
+                    "explorer"
+                  ],
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "outcome": {
+                "description": "Cross-checked against the surfaces themselves, so the summary cannot drift from the data it summarises.",
+                "enum": [
+                  "none-found",
+                  "surfaces-declared"
+                ],
+                "type": "string"
+              },
+              "searched_at": {
+                "description": "An absence with no date is not evidence.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "checked",
+              "outcome",
+              "searched_at"
+            ],
+            "type": "object"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "social": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SocialLinks"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source_repo": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/SubnetStatus"
+          },
+          "subnet_type": {
+            "$ref": "#/components/schemas/SubnetType"
+          },
+          "surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "symbol": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tempo": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "wallet_search": {
+            "additionalProperties": false,
+            "properties": {
+              "checked": {
+                "description": "Where the search actually looked. Without it, \"we searched\" is unfalsifiable and nobody else can re-run it. `chain` means the on-chain owner keys were read (SubnetOwner), which is always available and is NOT a declaration by the team.",
+                "items": {
+                  "enum": [
+                    "website",
+                    "docs",
+                    "blog",
+                    "source-repo",
+                    "explorer",
+                    "whitepaper",
+                    "chain"
+                  ],
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "outcome": {
+                "description": "Cross-checked against registry/entities/ itself, so the summary cannot drift from the data it summarises.",
+                "enum": [
+                  "none-found",
+                  "wallets-declared"
+                ],
+                "type": "string"
+              },
+              "searched_at": {
+                "description": "An absence with no date is not evidence.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "checked",
+              "outcome",
+              "searched_at"
+            ],
+            "type": "object"
+          },
+          "website_url": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "coverage_level",
+          "curation",
+          "curation_level",
+          "gaps",
+          "links",
+          "name",
+          "netuid",
+          "provenance",
+          "slug",
+          "status",
+          "subnet_type",
+          "surface_count"
+        ],
+        "type": "object"
+      },
+      "CurationMetadata": {
+        "additionalProperties": false,
+        "properties": {
+          "gap_notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "level": {
+            "$ref": "#/components/schemas/CurationLevel"
+          },
+          "review_state": {
+            "$ref": "#/components/schemas/ReviewState"
+          },
+          "reviewed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "verified_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "level",
+          "review_state"
+        ],
+        "type": "object"
+      },
+      "ReviewState": {
+        "enum": [
+          "unreviewed",
+          "machine-generated",
+          "maintainer-reviewed",
+          "needs-review",
+          "stale"
+        ],
+        "type": "string"
+      },
+      "Surface": {
+        "additionalProperties": false,
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/SurfaceAuth"
+          },
+          "auth_required": {
+            "type": "boolean"
+          },
+          "authority": {
+            "$ref": "#/components/schemas/Authority"
+          },
+          "classification": {
+            "$ref": "#/components/schemas/Classification"
+          },
+          "curation_level": {
+            "$ref": "#/components/schemas/CurationLevel"
+          },
+          "id": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/SurfaceKind"
+          },
+          "last_verified_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "method": {
+            "description": "HTTP method this surface is invoked with; absent means GET. A non-GET surface is a declared mutation (#11146): the prober never touches it (the manifest schema forbids an enabled probe on one), so it carries no probe-derived health -- reach it through call_subnet_surface's schema-gated execution.",
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "probe": {
+            "$ref": "#/components/schemas/ProbeConfig"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "public_safe": {
+            "type": "boolean"
+          },
+          "quality_signals": {
+            "$ref": "#/components/schemas/SurfaceQualitySignals"
+          },
+          "rate_limit": {
+            "$ref": "#/components/schemas/SurfaceRateLimit"
+          },
+          "rate_limit_notes": {
+            "type": "string"
+          },
+          "revenue": {
+            "additionalProperties": false,
+            "properties": {
+              "circularity": {
+                "description": "Whether the money originates outside Bittensor. Absent means unknown, never external.",
+                "enum": [
+                  "external",
+                  "alpha-denominated",
+                  "team-funded",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "currency": {
+                "description": "Unit the amount field carries. Declared rather than inferred from the path: api.chutes.ai/payments/summary/tao is named for TAO and its values reconcile as USD.",
+                "enum": [
+                  "USD",
+                  "TAO",
+                  "ALPHA"
+                ],
+                "type": "string"
+              },
+              "excludes": {
+                "description": "Fields present in the payload that are NOT external revenue and must be subtracted -- subnet-funded or unrecognised components.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "fields": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Map of role -> field name in the upstream payload, e.g. {date: 'date', amount: 'total_revenue'}.",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "grain": {
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "cumulative"
+                ],
+                "type": "string"
+              },
+              "provenance": {
+                "description": "Evidence class. Only chain-verified and probe-derived count toward a published coverage ratio; the rest are shown beside it and never summed in.",
+                "enum": [
+                  "chain-verified",
+                  "probe-derived",
+                  "operator-attested",
+                  "third-party-reported",
+                  "proxy-only",
+                  "none"
+                ],
+                "type": "string"
+              },
+              "role": {
+                "description": "What this surface actually measures. A 'stats' endpoint is guilty until proven revenue: miner payout is emission -- the denominator -- and counting it as revenue puts the denominator in the numerator.",
+                "enum": [
+                  "external-revenue",
+                  "usage-proxy",
+                  "miner-payout",
+                  "not-revenue"
+                ],
+                "type": "string"
+              },
+              "rows": {
+                "description": "The envelope key holding the payload `shape` describes, for a source that wraps its rows (a pagination envelope's `items`). Absent means the payload IS the rows.",
+                "type": "string"
+              },
+              "searched_at": {
+                "description": "When absence was established. Required for provenance 'none': an undated absence is not evidence.",
+                "type": "string"
+              },
+              "shape": {
+                "description": "How the payload is arranged, so an extractor does not have to guess. flat-array: a list of records, fields.date/fields.amount naming keys within one. keyed-map: nested {period: {subkey: amount}}, where the period IS the key and there are no field names to point at. scalar: one object carrying a single total.",
+                "enum": [
+                  "flat-array",
+                  "keyed-map",
+                  "scalar"
+                ],
+                "type": "string"
+              },
+              "source_url": {
+                "format": "uri",
+                "type": "string"
+              },
+              "supersedes": {
+                "description": "Surface ids this one subsumes. Declares a subset relationship so overlapping channels are not summed twice.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "provenance",
+              "role"
+            ],
+            "type": "object"
+          },
+          "review": {
+            "additionalProperties": false,
+            "properties": {
+              "confidence": {
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "type": "string"
+              },
+              "review_notes": {
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "community-submitted",
+                  "maintainer-reviewed",
+                  "rejected"
+                ],
+                "type": "string"
+              },
+              "submitted_at": {
+                "type": "string"
+              },
+              "submitted_by": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "state"
+            ],
+            "type": "object"
+          },
+          "schema_status": {
+            "enum": [
+              "machine-readable",
+              "ui-only",
+              "not-captured"
+            ],
+            "type": "string"
+          },
+          "schema_url": {
+            "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?):\\/\\/",
+            "type": "string"
+          },
+          "source_urls": {
+            "items": {
+              "format": "uri",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "stale": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether this surface's verification is older than its kind's freshness TTL. NULL when the surface has never been verified (#9906): that is unverified, not fresh, and 78% of surfaces were in that state while publishing false. Same unknown-is-not-a-value convention as `exists` on /crowdloans/{id}, `leased` on /subnets/{netuid}/lease, and lane_health's `verdict: unknown`."
+          },
+          "status": {
+            "$ref": "#/components/schemas/HealthStatus"
+          },
+          "subnet_name": {
+            "type": "string"
+          },
+          "subnet_slug": {
+            "type": "string"
+          },
+          "url": {
+            "pattern": "^(?:[Hh][Tt][Tt][Pp][Ss]?|[Ww][Ss][Ss]?):\\/\\/",
+            "type": "string"
+          },
+          "verification": {
+            "additionalProperties": false,
+            "properties": {
+              "archived": {
+                "type": "boolean"
+              },
+              "classification": {
+                "$ref": "#/components/schemas/Classification"
+              },
+              "confidence_score": {
+                "maximum": 100,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "content_type": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "default_branch": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "error": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "github_api_url": {
+                "format": "uri",
+                "type": "string"
+              },
+              "homepage": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "last_push_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "latency_ms": {
+                "anyOf": [
+                  {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "method_tested": {
+                "type": "string"
+              },
+              "redirect_target": {
+                "anyOf": [
+                  {
+                    "format": "uri",
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "status_code": {
+                "anyOf": [
+                  {
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "topics": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "verified_at": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "auth_required",
+          "authority",
+          "id",
+          "kind",
+          "netuid",
+          "provider",
+          "public_safe",
+          "url"
+        ],
+        "type": "object"
+      },
+      "ProbeConfig": {
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "expect": {
+            "enum": [
+              "json",
+              "html",
+              "sse",
+              "any"
+            ],
+            "type": "string"
+          },
+          "method": {
+            "enum": [
+              "GET",
+              "HEAD",
+              "JSON-RPC",
+              "WSS-RPC"
+            ],
+            "type": "string"
+          },
+          "timeout_ms": {
+            "maximum": 30000,
+            "minimum": 1000,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "enabled",
+          "expect",
+          "method"
+        ],
+        "type": "object"
+      },
+      "HealthSubnetArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "contract_version": {
+            "type": "string"
+          },
+          "generated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "health_source": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "operational_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/HealthSubnetSummary"
+          },
+          "surfaces": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "classification": {
+                  "$ref": "#/components/schemas/Classification"
+                },
+                "kind": {
+                  "$ref": "#/components/schemas/SurfaceKind"
+                },
+                "last_checked": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "last_ok": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "latency_ms": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "netuid": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "observed_by": {
+                  "const": "live-cron-prober",
+                  "type": "string"
+                },
+                "provider": {
+                  "type": "string"
+                },
+                "status": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                },
+                "status_code": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "surface_id": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "surface_id",
+                "netuid",
+                "kind",
+                "provider",
+                "url",
+                "status",
+                "observed_by"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "summary",
+          "surfaces"
+        ],
+        "type": "object"
+      },
+      "HealthSubnetSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "avg_latency_ms": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "degraded_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "failed_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "last_checked": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "last_ok": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "latency_sample_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "ok_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/HealthStatus"
+          },
+          "surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "unknown_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "degraded_count",
+          "failed_count",
+          "ok_count",
+          "status",
+          "surface_count",
+          "unknown_count"
+        ],
+        "type": "object"
+      },
+      "SubnetSurfacesArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "contract_version": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "surfaces": {
+            "items": {
+              "$ref": "#/components/schemas/Surface"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "generated_at",
+          "schema_version",
+          "netuid",
+          "surfaces"
+        ],
+        "type": "object"
+      },
+      "SubnetEndpointsArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "contract_version": {
+            "type": "string"
+          },
+          "endpoints": {
+            "items": {
+              "$ref": "#/components/schemas/EndpointResource"
+            },
+            "type": "array"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "health_source": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "operational_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/EndpointSummary"
+          }
+        },
+        "required": [
+          "generated_at",
+          "schema_version",
+          "netuid",
+          "summary",
+          "endpoints"
+        ],
+        "type": "object"
+      },
+      "EndpointSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "by_kind": {
+            "additionalProperties": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "by_layer": {
+            "additionalProperties": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "by_provider": {
+            "additionalProperties": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "by_publication_state": {
+            "additionalProperties": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "by_status": {
+            "additionalProperties": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "endpoint_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "monitored_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pool_eligible_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "endpoint_count",
+          "monitored_count",
+          "pool_eligible_count"
+        ],
+        "type": "object"
+      },
+      "SearchArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "contract_version": {
+            "type": "string"
+          },
+          "document_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "documents": {
+            "description": "Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON.",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "artifact_path": {
+                  "type": "string"
+                },
+                "categories": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "netuid": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "service_kinds": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "slug": {
+                  "type": "string"
+                },
+                "subtitle": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "tokens": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": {
+                  "enum": [
+                    "subnet",
+                    "surface",
+                    "provider"
+                  ],
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "type",
+                "title",
+                "artifact_path",
+                "tokens"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          }
+        },
+        "required": [
+          "generated_at",
+          "schema_version",
+          "document_count",
+          "documents"
+        ],
+        "type": "object"
+      },
+      "SemanticSearchArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "model": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "results": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "categories": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "netuid": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "score": {
+                  "type": "number"
+                },
+                "service_kinds": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "slug": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "subtitle": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "title": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "url": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "score",
+                "type",
+                "netuid",
+                "slug",
+                "title",
+                "categories",
+                "service_kinds"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "query",
+          "count",
+          "results",
+          "model"
+        ],
+        "type": "object"
+      },
+      "AskRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "question": {
+            "description": "The question to answer, in plain language. Exploratory questions work best (\"which subnets expose a public inference API?\"); for ranked matches rather than prose, use GET /api/v1/search/semantic.",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "question"
+        ],
+        "type": "object"
+      },
+      "AskArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "answer": {
+            "type": "string"
+          },
+          "citations": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "netuid": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "ref": {
+                  "maximum": 9007199254740991,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "score": {
+                  "type": "number"
+                },
+                "slug": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "title": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "url": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "ref",
+                "score",
+                "title",
+                "netuid",
+                "slug",
+                "url"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "context_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "model": {
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "question",
+          "answer",
+          "citations",
+          "context_count",
+          "model"
+        ],
+        "type": "object"
+      },
+      "SurfacesArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "contract_version": {
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          },
+          "surfaces": {
+            "items": {
+              "$ref": "#/components/schemas/Surface"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "generated_at",
+          "schema_version",
+          "surfaces"
+        ],
+        "type": "object"
+      },
+      "CoverageArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "application_subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "candidate_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "candidate_subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "chain_subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "completeness": {
+            "$ref": "#/components/schemas/CoverageCompleteness"
+          },
+          "contract_version": {
+            "type": "string"
+          },
+          "curated_overlay_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "curation_level_counts": {
+            "$ref": "#/components/schemas/CountMap"
+          },
+          "domain_coverage": {
+            "$ref": "#/components/schemas/CountMap"
+          },
+          "first_party_subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "manifested_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "native_only_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "native_only_with_candidates": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "native_only_without_candidates": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "native_snapshot_captured_at": {
+            "type": "string"
+          },
+          "network": {
+            "$ref": "#/components/schemas/BittensorNetwork"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "official_surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "probed_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "probed_surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "registry_observed_surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "root_subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          },
+          "source": {
+            "additionalProperties": false,
+            "properties": {
+              "candidates": {
+                "type": "string"
+              },
+              "native": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "identity_storage": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "method": {
+                        "type": "string"
+                      },
+                      "package": {
+                        "type": "string"
+                      },
+                      "rpc_family": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                ]
+              },
+              "overlays": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "candidates",
+              "native",
+              "overlays"
+            ],
+            "type": "object"
+          },
+          "subnets_without_official_surface": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "generated_at",
+          "schema_version",
+          "application_subnet_count",
+          "candidate_count",
+          "candidate_subnet_count",
+          "chain_subnet_count",
+          "curated_overlay_count",
+          "curation_level_counts",
+          "manifested_count",
+          "native_only_count",
+          "native_only_with_candidates",
+          "native_only_without_candidates",
+          "native_snapshot_captured_at",
+          "network",
+          "probed_count",
+          "probed_surface_count",
+          "root_subnet_count",
+          "source",
+          "surface_count"
+        ],
+        "type": "object"
+      },
+      "CoverageCompleteness": {
+        "additionalProperties": false,
+        "properties": {
+          "average_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "dimension_coverage": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "pct": {
+                  "maximum": 100,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "present": {
+                  "description": "Subnets carrying at least one surface of this kind.",
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "pct",
+                "present"
+              ],
+              "type": "object"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "fully_complete_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "fully_complete_pct": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "median_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "methodology": {
+            "type": "string"
+          },
+          "score_distribution": {
+            "additionalProperties": {
+              "maximum": 9007199254740991,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "scored_subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "CountMap": {
+        "additionalProperties": {
+          "maximum": 9007199254740991,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "EconomicsArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "captured_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "chain_state": {
+            "$ref": "#/components/schemas/ChainState"
+          },
+          "contract_version": {
+            "type": "string"
+          },
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "network": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          },
+          "subnets": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEconomics"
+            },
+            "type": "array"
+          },
+          "summary": {
+            "additionalProperties": false,
+            "properties": {
+              "registration_open_count": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "subnet_count": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_alpha_value_tao": {
+                "description": "Sum of every non-root subnet's alpha_market_cap_tao -- rao-precision decimal string (#6641).",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
+              },
+              "total_miners": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_network_value_tao": {
+                "description": "total_root_value_tao + total_alpha_value_tao -- Backprop's Total Network Value (#6641).",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
+              },
+              "total_root_value_tao": {
+                "description": "Root (netuid 0) TAO-denominated stake -- rao-precision decimal string (#6641).",
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
+              },
+              "total_stake_alpha": {
+                "pattern": "^\\d+\\.\\d{9}$",
+                "type": "string"
+              },
+              "total_validators": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              "with_economics_count": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "registration_open_count",
+              "subnet_count",
+              "total_alpha_value_tao",
+              "total_miners",
+              "total_network_value_tao",
+              "total_root_value_tao",
+              "total_stake_alpha",
+              "total_validators",
+              "with_economics_count"
+            ],
+            "type": "object"
+          },
+          "tao_usd": {
+            "additionalProperties": false,
+            "description": "The reading every _usd field was converted at. Rides at the blob level because ONE reading priced all of them.",
+            "properties": {
+              "block_number": {
+                "anyOf": [
+                  {
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "observed_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "price_basis": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "usd_per_tao": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "usd_per_tao",
+              "block_number",
+              "observed_at",
+              "price_basis"
+            ],
+            "type": "object"
+          },
+          "tao_usd_unavailable": {
+            "description": "Why there are no _usd fields. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero.",
+            "enum": [
+              "no_index_reading",
+              "index_unpriced",
+              "index_stale",
+              "no_alpha_price"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "generated_at",
+          "schema_version",
+          "captured_at",
+          "network",
+          "subnets",
+          "summary"
+        ],
+        "type": "object"
+      },
+      "ChainState": {
+        "additionalProperties": false,
+        "description": "The chain state the decomposition's inputs were pinned to. theta/q/h are read AS STORED at this block -- the runtime gates with the stored bar between its 360-block recomputes, so a live read is the wrong number for 359 blocks out of 360.",
+        "properties": {
+          "block": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "block_hash": {
+            "description": "The block hash, so the pinning is exact -- a height alone is ambiguous across a reorg.",
+            "pattern": "^0x[0-9a-fA-F]{64}$",
+            "type": "string"
+          },
+          "emission_bar_quantile": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "emission_gate_bar": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "theta. Null when the bar is unset, which disables the gate outright."
+          },
+          "emission_gate_exponent": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "h. Null means the runtime default 3, NOT zero -- h = 0 makes the Hill gate a constant 0.5 for every subnet."
+          },
+          "network_immunity_period": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SubtensorModule.NetworkImmunityPeriod -- how many blocks after registration a subnet cannot be deregistered. Null on a blob captured before this read existed."
+          },
+          "total_issuance_tao": {
+            "minimum": 0,
+            "type": "number"
+          }
+        },
+        "required": [
+          "block",
+          "block_hash",
+          "total_issuance_tao",
+          "emission_gate_bar",
+          "emission_bar_quantile",
+          "emission_gate_exponent"
+        ],
+        "type": "object"
+      },
+      "GlobalValidatorsArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "block_number": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "captured_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "limit": {
+            "maximum": 2000,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "schema_version": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "sort": {
+            "enum": [
+              "avg_validator_trust",
+              "max_validator_trust",
+              "stake_dominance",
+              "subnet_count",
+              "total_emission",
+              "total_stake",
+              "uid_count"
+            ],
+            "type": "string"
+          },
+          "validator_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "validators": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "alpha_stake_tao": {
+                  "description": "The non-root leg of total_stake_tao, TAO-priced (#9051): the current market value of every alpha delegation the priced total covers. total_stake_tao = root_stake_tao + alpha_stake_tao, exactly.",
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "apy_estimate": {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "apy_estimate_eligible_subnet_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "avg_validator_trust": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "coldkey": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "coldkey_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "coldkey_identity": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "Self-reported on-chain identity (SubtensorModule::set_identity) for a `coldkey`.",
+                      "properties": {
+                        "additional": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "captured_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "description": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "discord": {
+                          "anyOf": [
+                            {
+                              "maxLength": 200,
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "github": {
+                          "anyOf": [
+                            {
+                              "format": "uri",
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "has_identity": {
+                          "type": "boolean"
+                        },
+                        "image": {
+                          "anyOf": [
+                            {
+                              "format": "uri",
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "name": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "url": {
+                          "anyOf": [
+                            {
+                              "format": "uri",
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "has_identity",
+                        "name",
+                        "url",
+                        "github",
+                        "image",
+                        "discord",
+                        "description",
+                        "additional",
+                        "captured_at"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "featured": {
+                  "type": "boolean"
+                },
+                "hotkey": {
+                  "type": "string"
+                },
+                "latest_block_number": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "latest_captured_at": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "max_validator_trust": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "nominator_count": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Distinct coldkeys with stake delegated to this validator's hotkey, from the poller's exhaustive SubtensorModule::Alpha scan (24h cadence). A validator absent from a FRESH scan reads as 0 rather than null: the pass covers the whole keyspace, so absence is a confirmed zero rather than a gap (#9314). null means the scan itself is stale or unavailable -- the count is unknown, not zero."
+                },
+                "realized_return_1d": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Realized return on staked capital over a NOMINAL 1-day window. The interval is not exact: the baseline is the newest neuron_daily snapshot within a 2-day tolerance of the target date (#8837), so this can measure 1, 2 or 3 elapsed days. Read realized_return_1d_as_of for the day it actually resolved to before annualizing or plotting day-over-day (#9885)."
+                },
+                "realized_return_1d_as_of": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The neuron_daily snapshot_date the 1-day baseline resolved to, or null when there is no baseline (in which case realized_return_1d is null too). Subtract it from the response stamp for the true elapsed interval."
+                },
+                "realized_return_1m": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Realized return over a NOMINAL 30-day window; the same 2-day tolerance makes the true interval 28-32 days. See realized_return_1m_as_of (#9885)."
+                },
+                "realized_return_1m_as_of": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The neuron_daily snapshot_date the 30-day baseline resolved to, or null when realized_return_1m is null."
+                },
+                "realized_return_1w": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Realized return over a NOMINAL 7-day window; the same 2-day tolerance makes the true interval 5-9 days. See realized_return_1w_as_of (#9885)."
+                },
+                "realized_return_1w_as_of": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The neuron_daily snapshot_date the 7-day baseline resolved to, or null when realized_return_1w is null."
+                },
+                "root_stake_tao": {
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "stake_dominance": {
+                  "anyOf": [
+                    {
+                      "maximum": 1,
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "subnet_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "subnets": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "emission_alpha": {
+                        "description": "This row's emission on the subnet named by the sibling `netuid`, alpha-denominated for the same reason as the sibling stake field. Renamed from `emission_tao` in #10514.",
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "netuid": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "stake_alpha": {
+                        "description": "This row's stake on the subnet named by the sibling `netuid`. ALPHA for non-root subnets, genuine TAO on root (#2550). Renamed from `stake_tao` in #10514: the entry's own `total_stake_tao` IS priced TAO, and two fields sharing the `_tao` suffix while carrying different units is a trap no description undoes. Never summable across subnets -- the priced total already did that conversion.",
+                        "minimum": 0,
+                        "type": "number"
+                      },
+                      "uid": {
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "validator_trust": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "netuid",
+                      "uid",
+                      "stake_alpha",
+                      "emission_alpha",
+                      "validator_trust"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 10,
+                  "type": "array"
+                },
+                "take": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "total_emission_tao": {
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest SPOT price -- tao_in_pool_tao / alpha_in_pool from that subnet's newest snapshot, root at 1:1 -- before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Marked at SPOT, not at alpha_price_tao: that field is the chain's MOVING price (#9408), and a lagging average is the wrong mark for what a position is worth -- measured -1.29% against spot on netuid 64 for 2026-08-03. Prices still come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier; the lag is the rollup's, no longer the average's.",
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "total_stake_tao": {
+                  "description": "Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest SPOT price -- tao_in_pool_tao / alpha_in_pool from that subnet's newest snapshot, root at 1:1 -- before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Marked at SPOT, not at alpha_price_tao: that field is the chain's MOVING price (#9408), and a lagging average is the wrong mark for what a position is worth -- measured -1.29% against spot on netuid 64 for 2026-08-03. Prices still come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier; the lag is the rollup's, no longer the average's.",
+                  "minimum": 0,
+                  "type": "number"
+                },
+                "uid_count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "hotkey",
+                "featured",
+                "coldkey",
+                "coldkey_identity",
+                "coldkey_count",
+                "subnet_count",
+                "uid_count",
+                "take",
+                "total_stake_tao",
+                "root_stake_tao",
+                "alpha_stake_tao",
+                "total_emission_tao",
+                "nominator_count",
+                "apy_estimate",
+                "apy_estimate_eligible_subnet_count",
+                "realized_return_1d",
+                "realized_return_1d_as_of",
+                "realized_return_1w",
+                "realized_return_1w_as_of",
+                "realized_return_1m",
+                "realized_return_1m_as_of",
+                "stake_dominance",
+                "avg_validator_trust",
+                "max_validator_trust",
+                "latest_captured_at",
+                "latest_block_number",
+                "subnets"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "schema_version",
+          "sort",
+          "limit",
+          "block_number",
+          "captured_at",
+          "validator_count",
+          "validators"
+        ],
+        "type": "object"
+      },
+      "AccountSummaryArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "activity": {
+            "additionalProperties": false,
+            "description": "Signing-activity aggregate from the extrinsics tier, matched by signer only. tx_count / total_fee_tao / last_tx_* are all-time over every extrinsic this address has signed; modules_called is the pallet mix over the newest 1000 only, with modules_called_capped true when that window is incomplete. An account queried by a key that did not sign returns tx_count 0, modules_called_capped false, other fields null/empty.",
+            "properties": {
+              "last_tx_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "last_tx_block": {
+                "anyOf": [
+                  {
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "modules_called": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "call_module": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "call_module",
+                    "count"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "modules_called_capped": {
+                "type": "boolean"
+              },
+              "total_fee_tao": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "tx_count": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "tx_count",
+              "last_tx_block",
+              "last_tx_at",
+              "total_fee_tao",
+              "modules_called",
+              "modules_called_capped"
+            ],
+            "type": "object"
+          },
+          "event_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "event_kinds": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "count": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "kind": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "count"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "event_scan_capped": {
+            "description": "True when this account has more events than the summary's scan window -- event_count/subnet_count/event_kinds are then a lower bound and first_block/first_seen_at are null. False means the totals are the account's complete history, at any magnitude: when the account-summary projection answers, the counts are running totals folded over the whole history rather than a scan of the newest N, so a large event_count here is exact rather than truncated.",
+            "type": "boolean"
+          },
+          "first_block": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "first_seen_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "labels": {
+            "items": {
+              "additionalProperties": false,
+              "description": "A community-contributed entity label for an address (exchange/foundation/operator/other).",
+              "properties": {
+                "category": {
+                  "anyOf": [
+                    {
+                      "enum": [
+                        "exchange",
+                        "bridge",
+                        "foundation",
+                        "pool",
+                        "infra",
+                        "project",
+                        "operator",
+                        "other",
+                        "payment-collector",
+                        "treasury",
+                        "burn",
+                        "multisig"
+                      ],
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "name": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "notes": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "source_urls": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "url": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "last_block": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "last_seen_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "recent_events": {
+            "items": {
+              "$ref": "#/components/schemas/AccountEvent"
+            },
+            "type": "array"
+          },
+          "registrations": {
+            "description": "Where this hotkey is currently registered + staked (the live cross-subnet footprint).",
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "active": {
+                  "type": "boolean"
+                },
+                "netuid": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "stake_tao": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "uid": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "validator_permit": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "netuid",
+                "uid",
+                "stake_tao",
+                "validator_permit",
+                "active"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "schema_version": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "ss58": {
+            "type": "string"
+          },
+          "subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "schema_version",
+          "ss58",
+          "event_count",
+          "registrations"
+        ],
+        "type": "object"
+      },
+      "AccountEvent": {
+        "additionalProperties": false,
+        "properties": {
+          "alpha_amount": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "amount_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "block_number": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "coldkey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "event_index": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "event_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "extrinsic_index": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "hotkey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "netuid": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "observed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "price_at_tx": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "price_basis": {
+            "anyOf": [
+              {
+                "enum": [
+                  "trade_exact",
+                  "root_no_pool"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "uid": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "usd_at_tx": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "usd_basis": {
+            "anyOf": [
+              {
+                "enum": [
+                  "index_at_or_before"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "block_number",
+          "event_kind"
+        ],
+        "type": "object"
+      },
+      "HealthSummaryArtifact": {
+        "additionalProperties": false,
+        "properties": {
+          "contract_version": {
+            "type": "string"
+          },
+          "generated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "global": {
+            "additionalProperties": false,
+            "properties": {
+              "status_counts": {
+                "additionalProperties": {
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "surface_count": {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "health_source": {
+            "type": "string"
+          },
+          "operational_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_version": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "subnets": {
+            "items": {
+              "$ref": "#/components/schemas/HealthSubnetSummary"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "global",
+          "schema_version",
+          "subnets"
+        ],
+        "type": "object"
+      },
+      "ChainEventsFeedArtifact": {
+        "additionalProperties": false,
+        "description": "Paginated all-events feed from the chain_events lakehouse table. Mirrors GET /api/v1/chain-events (and MCP list_chain_events). Distinct from Subscription.chainEvents.",
+        "properties": {
+          "count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "events": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "args": {
+                  "anyOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "items": {},
+                          "type": "array"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "block_number": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "event_index": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "extrinsic_index": {
+                  "anyOf": [
+                    {
+                      "maximum": 9007199254740991,
+                      "minimum": -9007199254740991,
+                      "type": "integer"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "method": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "observed_at": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/EpochMillis"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "pallet": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "phase": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "summary": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "block_number",
+                "event_index",
+                "pallet",
+                "method"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "next_before": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "count",
+          "events"
+        ],
+        "type": "object"
+      },
+      "EpochMillis": {
+        "description": "An epoch-millisecond instant. Published as Float in GraphQL: the value exceeds the 32-bit range of GraphQL's Int.",
+        "maximum": 9007199254740991,
+        "minimum": 0,
+        "type": "integer"
+      }
+    },
+    "headers": {
+      "CacheControl": {
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ETag": {
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ContractVersion": {
+        "schema": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `providers/metagraphed/bittensor` — an operational and integration registry for [Bittensor](https://bittensor.com).

## What it serves

What each active Bittensor subnet publishes (REST APIs, docs, schemas), whether those surfaces are up, and how to call them — alongside the chain itself: blocks, extrinsics, balances, stake positions, emissions and validator economics.

Every catalogued surface carries a `source_url` proving the subnet publishes it, and health, uptime and latency are derived from scheduled probes rather than asserted.

## Two tiers

**Free** — the registry, discovery, health, schema and economics layer, plus a grounded natural-language `ask` and semantic search. Served anonymously. Presenting a payment on one of these buys rate and quota headroom rather than access, and a request without one is never refused.

**Paid** — `GET /api/v1/export/chain-events` answers `402` with an x402 quote. Up to 25,000 chain events in one call against the free route's 100 — same rows, filters and ordering, without the page ceiling or the cursor bookkeeping. It is the only route that requires payment, because a single unpaginated pass over the lakehouse is the shape that costs real money to serve.

## Payment

x402 v2, `exact` scheme, settled through the public facilitator. Every quote carries a **Solana (USDC) leg and a Base leg**, so a client pays with whichever it holds:

```
$ curl https://api.metagraph.sh/api/v1/export/chain-events
402
  eip155:84532                             amount=24000  asset=0x036CbD53…
  solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1  amount=24000  asset=EPjFWdd5Au…
```

`GET /.well-known/x402` publishes the accepted networks and addresses.

## Validation

`pay catalog check` with your CI's exact invocation, against production:

```
Solana-compat verdict
PASS   metagraphed/bittensor (1/1)
  OK    GET api/v1/export/chain-events   paid via x402 (ok)
  FREE  … 14 endpoints
│ Changed providers check successful
│ 16 endpoints tested across 1 provider
│ 1/1 gates compatible with Solana
```

Whole-registry static check (`catalog check . --no-probe`) also passes with this entry added — 913 endpoints across 75 providers, none of the warnings from this provider.

The OpenAPI document is committed alongside `PAY.md` as a trimmed, self-contained snapshot of the 16 catalogued endpoints (all `$ref`s resolved locally, no external references).