### PR TITLE
feat(optimai): add Solana x402 search provider

### DIFF
--- a/providers/optimai/search/PAY.md
+++ b/providers/optimai/search/PAY.md
@@ -11,6 +11,10 @@ openapi:
 
 OptimAI Search gives agents current, source-backed context through a paid x402 endpoint. It searches web, social, and crypto sources and returns a contextual answer with citations. The same endpoint accepts x402 payment on Base and Solana mainnet in USDC.
 
+## Request lifecycle
+
+The paid `POST /external/v1/x402/search` returns `202` with a search `id`. Poll `GET /external/v1/x402/search/{id}` with the `PAYMENT-SIGNATURE` header to read progress and retrieve the completed answer with citations. A completed result that is still verified but unsettled returns a fresh x402 payment challenge before the result is released.
+
 ## Spend-aware usage
 
 - Ask one focused question per call.

--- a/providers/optimai/search/PAY.md
+++ b/providers/optimai/search/PAY.md
@@ -1,0 +1,22 @@
+---
+name: search
+title: "OptimAI"
+description: "OptimAI is an agent-ready decentralized search and retrieval service powered by OptimAI Network nodes, returning real-time contextual answers with citations from web, social, and crypto sources."
+use_case: "Use for current web research, source-backed answers, social and crypto discovery, fact checking, and citation-rich searches when an agent needs live information."
+category: search
+service_url: https://api-onchain.optimai.network
+openapi:
+  path: openapi.json
+---
+
+OptimAI Search gives agents current, source-backed context through a paid x402 endpoint. It searches web, social, and crypto sources and returns a contextual answer with citations. The same endpoint accepts x402 payment on Base and Solana mainnet in USDC.
+
+## Spend-aware usage
+
+- Ask one focused question per call.
+- Reuse a prior answer's citations and identifiers before paying for another search.
+- Use the smallest query that answers the task; avoid repeating equivalent searches.
+
+## SDK
+
+For TypeScript integrations, use the [OptimAI x402 SDK](https://www.npmjs.com/package/@optimai-network/x402-sdk).

--- a/providers/optimai/search/PAY.md
+++ b/providers/optimai/search/PAY.md
@@ -13,7 +13,7 @@ OptimAI Search gives agents current, source-backed context through a paid x402 e
 
 ## Request lifecycle
 
-The paid `POST /external/v1/x402/search` returns `202` with a search `id`. Poll `GET /external/v1/x402/search/{id}` with the `PAYMENT-SIGNATURE` header to read progress and retrieve the completed answer with citations. A completed result that is still verified but unsettled returns a fresh x402 payment challenge before the result is released.
+Omit `PAYMENT-SIGNATURE` on the initial `POST /external/v1/x402/search`. If it returns `402`, read the `PAYMENT-REQUIRED` header, complete one accepted x402 payment on Base or Solana mainnet USDC, and retry the POST with `PAYMENT-SIGNATURE`. The paid request returns `202` with a search `id`. Poll `GET /external/v1/x402/search/{id}` with the same `PAYMENT-SIGNATURE` header to read progress and retrieve the completed answer with citations. A completed result that is still verified but unsettled returns a fresh x402 payment challenge before the result is released.
 
 ## Spend-aware usage
 

--- a/providers/optimai/search/openapi.json
+++ b/providers/optimai/search/openapi.json
@@ -4,7 +4,7 @@
     "title": "OptimAI x402 API",
     "description": "OptimAI is an agent-ready decentralized search and retrieval service powered by the OptimAI Network nodes, returning real-time contextual answers with citations from web, social, and crypto sources.",
     "version": "1.0.0",
-    "x-guidance": "Use POST /external/v1/x402/search with application/json {\"query\":\"...\"}. If the response is 402, read the payment-required header, satisfy one accepted x402 v2 payment requirement, then retry with PAYMENT-SIGNATURE. A successful paid request returns an accepted OptimAI Search request for agent-ready web, social, and crypto research with cited results."
+    "x-guidance": "Use POST /external/v1/x402/search with application/json {\"query\":\"...\"}. If the response is 402, read the payment-required header, satisfy one accepted x402 v2 payment requirement, then retry with PAYMENT-SIGNATURE. A successful paid request returns an id; poll GET /external/v1/x402/search/{id} with PAYMENT-SIGNATURE for progress and the cited result. A completed result that is still verified but unsettled returns a fresh payment challenge before release."
   },
   "servers": [
     {
@@ -12,12 +12,196 @@
       "description": "Production"
     }
   ],
+  "components": {
+    "schemas": {
+      "X402SearchResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "planning",
+              "searching",
+              "processing",
+              "aggregating",
+              "completed",
+              "failed",
+              "cancelled"
+            ]
+          },
+          "query": {
+            "type": "string"
+          },
+          "x402_payment_status": {
+            "type": "string",
+            "enum": [
+              "verified_unsettled",
+              "settled",
+              "voided",
+              "settlement_failed"
+            ]
+          },
+          "progress": {
+            "type": "object",
+            "properties": {
+              "stage": {
+                "type": "string"
+              },
+              "percent": {
+                "type": "number"
+              },
+              "current_step": {
+                "type": "string"
+              },
+              "sources_found": {
+                "type": "integer"
+              },
+              "sources_analyzed": {
+                "type": "integer"
+              },
+              "sources_relevant": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "stage"
+            ]
+          },
+          "result": {
+            "type": "object",
+            "properties": {
+              "answer": {
+                "type": "string"
+              },
+              "summary": {
+                "type": "string"
+              },
+              "citations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer"
+                    },
+                    "url": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "snippet": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "domain": {
+                      "type": "string"
+                    },
+                    "published_date": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "url"
+                  ]
+                }
+              },
+              "related_questions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sources_found": {
+                "type": "integer"
+              },
+              "sources_analyzed": {
+                "type": "integer"
+              },
+              "sources_relevant": {
+                "type": "integer"
+              },
+              "search_queries_used": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "answer",
+              "citations"
+            ]
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "query"
+        ]
+      },
+      "ExternalApiError": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "code",
+              "message"
+            ]
+          },
+          "request_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      }
+    }
+  },
   "paths": {
     "/external/v1/x402/search": {
       "post": {
         "operationId": "createX402Search",
         "summary": "Create an x402-paid OptimAI Search request",
-        "description": "Submit a natural-language search or research question and receive an asynchronous OptimAI Search request.",
+        "description": "Submit a natural-language search or research question and receive an asynchronous OptimAI Search request. Use the returned id with GET /external/v1/x402/search/{id} to retrieve progress and the completed answer with citations.",
         "x-payment-info": {
           "protocols": [
             {
@@ -68,13 +252,109 @@
         },
         "responses": {
           "202": {
-            "description": "Search request accepted after x402 payment verification."
+            "description": "Search request accepted after x402 payment verification. The response body contains the request id for status and result retrieval.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402SearchResponse"
+                },
+                "example": {
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "status": "pending",
+                  "query": "What is OptimAI?",
+                  "x402_payment_status": "verified_unsettled"
+                }
+              }
+            },
+            "links": {
+              "getX402Search": {
+                "operationId": "getX402Search",
+                "parameters": {
+                  "id": "$response.body#/id"
+                },
+                "description": "Retrieve this request's progress or completed result."
+              }
+            }
           },
           "400": {
-            "description": "Invalid request body."
+            "description": "Invalid request body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalApiError"
+                }
+              }
+            }
           },
           "402": {
             "description": "Payment Required. Inspect the payment-required header for x402 requirements."
+          }
+        }
+      }
+    },
+    "/external/v1/x402/search/{id}": {
+      "get": {
+        "operationId": "getX402Search",
+        "summary": "Fetch an x402-paid OptimAI Search request",
+        "description": "Read the status and progress of a paid search, or retrieve its completed answer and citations. Send the original PAYMENT-SIGNATURE for payer-bound access. If a completed result is verified but not settled, the endpoint returns a fresh x402 payment challenge before releasing the result.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The search request id returned by the paid POST request.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current search status, progress, failure, or completed result. Completed results include citations when payment is settled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402SearchResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "A fresh result payment was accepted but settlement is still pending; retry the retrieval with the same payment context.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/X402SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid search request id. Validation happens before payment checks."
+          },
+          "401": {
+            "description": "A PAYMENT-SIGNATURE is required to read this search, or the supplied signature is not valid for the request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalApiError"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment Required. A completed but unsettled result needs a fresh x402 payment; inspect the payment-required header and retry with PAYMENT-SIGNATURE."
+          },
+          "404": {
+            "description": "Search request not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalApiError"
+                }
+              }
+            }
           }
         }
       }

--- a/providers/optimai/search/openapi.json
+++ b/providers/optimai/search/openapi.json
@@ -216,6 +216,17 @@
             "agentMultiplier": 2
           }
         },
+        "parameters": [
+          {
+            "name": "PAYMENT-SIGNATURE",
+            "in": "header",
+            "required": false,
+            "description": "x402 v2 payment signature. Omit it on the initial request to receive PAYMENT-REQUIRED; send it when retrying a paid request or polling a paid result.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -287,7 +298,15 @@
             }
           },
           "402": {
-            "description": "Payment Required. Inspect the payment-required header for x402 requirements."
+            "description": "Payment Required. Inspect the payment-required header for x402 requirements.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 v2 payment requirements returned with a 402 response.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -306,6 +325,15 @@
             "schema": {
               "type": "string",
               "format": "uuid"
+            }
+          },
+          {
+            "name": "PAYMENT-SIGNATURE",
+            "in": "header",
+            "required": false,
+            "description": "x402 v2 payment signature. Omit it on the initial request to receive PAYMENT-REQUIRED; send it when retrying a paid request or polling a paid result.",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -344,7 +372,15 @@
             }
           },
           "402": {
-            "description": "Payment Required. A completed but unsettled result needs a fresh x402 payment; inspect the payment-required header and retry with PAYMENT-SIGNATURE."
+            "description": "Payment Required. A completed but unsettled result needs a fresh x402 payment; inspect the payment-required header and retry with PAYMENT-SIGNATURE.",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "description": "Base64-encoded x402 v2 payment requirements returned with a 402 response.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "404": {
             "description": "Search request not found.",

--- a/providers/optimai/search/openapi.json
+++ b/providers/optimai/search/openapi.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OptimAI x402 API",
+    "description": "OptimAI is an agent-ready decentralized search and retrieval service powered by the OptimAI Network nodes, returning real-time contextual answers with citations from web, social, and crypto sources.",
+    "version": "1.0.0",
+    "x-guidance": "Use POST /external/v1/x402/search with application/json {\"query\":\"...\"}. If the response is 402, read the payment-required header, satisfy one accepted x402 v2 payment requirement, then retry with PAYMENT-SIGNATURE. A successful paid request returns an accepted OptimAI Search request for agent-ready web, social, and crypto research with cited results."
+  },
+  "servers": [
+    {
+      "url": "https://api-onchain.optimai.network",
+      "description": "Production"
+    }
+  ],
+  "paths": {
+    "/external/v1/x402/search": {
+      "post": {
+        "operationId": "createX402Search",
+        "summary": "Create an x402-paid OptimAI Search request",
+        "description": "Submit a natural-language search or research question and receive an asynchronous OptimAI Search request.",
+        "x-payment-info": {
+          "protocols": [
+            {
+              "x402": {}
+            }
+          ],
+          "price": {
+            "mode": "fixed",
+            "currency": "USD",
+            "amount": "0.001",
+            "pricingMode": "request-dependent",
+            "agentMultiplier": 2
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 1000,
+                    "description": "Natural-language search or research question."
+                  },
+                  "search_mode": {
+                    "type": "string",
+                    "enum": [
+                      "search",
+                      "agent"
+                    ],
+                    "default": "search",
+                    "description": "Select standard Search or text-only Agent mode."
+                  }
+                },
+                "required": [
+                  "query"
+                ],
+                "additionalProperties": true
+              },
+              "example": {
+                "query": "What is OptimAI?"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Search request accepted after x402 payment verification."
+          },
+          "400": {
+            "description": "Invalid request body."
+          },
+          "402": {
+            "description": "Payment Required. Inspect the payment-required header for x402 requirements."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Add OptimAI Search to the public pay-skills catalog as a Solana-mainnet-compatible x402 provider.

## Reference

This listing follows OptimAI's existing Agentic Market / x402 Bazaar identity:

- Provider title: OptimAI
- Category: search
- Production service: https://api-onchain.optimai.network
- Endpoint: POST /external/v1/x402/search
- Description: agent-ready decentralized search with cited web, social, and crypto results

## Changes

- Add `providers/optimai/search/PAY.md` with spend-aware usage guidance and SDK link.
- Commit the OpenAPI snapshot at `providers/optimai/search/openapi.json`.
- The live endpoint returns HTTP 402 with x402 v2 and accepts Solana mainnet USDC (as well as Base USDC).

## Verification

`npx @solana/pay catalog check providers/optimai/search/PAY.md -v`

- 1 endpoint tested
- 1/1 Solana compatibility gates passed
- Live probe returned `402 x402 USDC`
