### PR TITLE
feat(hilt): add transaction evidence API

### DIFF
--- a/providers/hilt/transaction-evidence/PAY.md
+++ b/providers/hilt/transaction-evidence/PAY.md
@@ -1,0 +1,24 @@
+---
+name: transaction-evidence
+title: "Hilt Solana Transaction Evidence"
+description: "Pay-per-request normalized evidence for finalized Solana transactions, including signers, invoked programs, SOL and token balance changes, parsed transfers, fees, timestamps, status and explicit ambiguity warnings."
+use_case: "Use for inspecting a finalized Solana transaction, normalizing payment evidence, reconciling transfer facts, identifying signers and programs, or comparing exact SOL and token balance changes without operating a transaction parser."
+category: data
+service_url: https://www.hilt.so
+version: v1
+openapi:
+  path: openapi.json
+---
+
+Hilt Solana Transaction Evidence turns one finalized mainnet transaction signature into a compact machine-readable evidence record.
+
+The endpoint costs 0.05 USDC per request through standard x402 V2 `exact` settlement on Solana. The buyer needs no Hilt account or API key. Send a fresh `request_id` for each new paid lookup and reuse it only when retrying that same operation.
+
+The response reports public-chain facts. It does not certify that a wallet, token, transaction, counterparty, or payment is universally safe, legitimate, or legally compliant. Apply expected-recipient, expected-asset, expected-amount, business-context, and risk policies separately.
+
+## Spend-aware usage
+
+- Reuse a result for the same finalized signature instead of paying for repeated lookups.
+- Use a fresh `request_id` for a genuinely new lookup; preserve it only across retries of that lookup.
+- Inspect `status` and `warnings` before treating balance changes as a completed payment.
+- Prefer the normalized balance and transfer arrays over making additional RPC calls when they already answer the task.

--- a/providers/hilt/transaction-evidence/openapi.json
+++ b/providers/hilt/transaction-evidence/openapi.json
@@ -1,0 +1,72 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Hilt Solana Transaction Evidence API",
+    "version": "1.0.0",
+    "description": "Pay-per-request normalized evidence for finalized Solana transactions. Payment uses x402 V2 with Solana USDC."
+  },
+  "servers": [{ "url": "https://www.hilt.so" }],
+  "paths": {
+    "/v1/solana/transaction-evidence": {
+      "post": {
+        "operationId": "getSolanaTransactionEvidence",
+        "summary": "Fetch finalized Solana transaction evidence",
+        "description": "Returns signers, invoked programs, SOL and token balance changes, parsed transfers, finality status, fee, timestamp and explicit evidence boundaries for one finalized Solana mainnet transaction.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/TransactionEvidenceRequest" },
+              "example": {
+                "request_id": "pay-sh-probe-2026-08-26",
+                "transaction_signature": "2Ana1pUpv2ZbMVkwF5FXapYeBEjdxDatLn7nvJkhgTSXbs59SyZSx866bXirPgj8QQVB57uxHJBG1YFvkRbFj4T"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Finalized transaction evidence" },
+          "402": {
+            "description": "Solana USDC payment required",
+            "headers": {
+              "PAYMENT-REQUIRED": {
+                "required": true,
+                "description": "Base64-encoded x402 V2 payment requirement.",
+                "schema": { "type": "string" }
+              }
+            }
+          },
+          "404": { "description": "Transaction not found at finalized commitment" },
+          "422": { "description": "Invalid request" },
+          "502": { "description": "Solana evidence provider unavailable" }
+        },
+        "x-payment-info": {
+          "price": { "mode": "fixed", "currency": "USD", "amount": "0.050000" },
+          "protocols": [{ "x402": {} }]
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TransactionEvidenceRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["request_id", "transaction_signature"],
+        "properties": {
+          "request_id": {
+            "type": "string",
+            "minLength": 8,
+            "maxLength": 120,
+            "pattern": "^[A-Za-z0-9._:-]{8,120}$",
+            "description": "Fresh retry key for one paid lookup. Reuse it only when retrying that same request."
+          },
+          "transaction_signature": {
+            "type": "string",
+            "description": "Solana transaction signature to inspect at finalized commitment."
+          }
+        }
+      }
+    }
+  }
+}

--- a/providers/hilt/transaction-evidence/openapi.json
+++ b/providers/hilt/transaction-evidence/openapi.json
@@ -25,7 +25,20 @@
           }
         },
         "responses": {
-          "200": { "description": "Finalized transaction evidence" },
+          "200": {
+            "description": "Finalized transaction evidence",
+            "headers": {
+              "PAYMENT-RESPONSE": {
+                "description": "Base64-encoded x402 V2 settlement response when this request settled a payment.",
+                "schema": { "type": "string" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TransactionEvidenceResponse" }
+              }
+            }
+          },
           "402": {
             "description": "Solana USDC payment required",
             "headers": {
@@ -36,9 +49,62 @@
               }
             }
           },
-          "404": { "description": "Transaction not found at finalized commitment" },
-          "422": { "description": "Invalid request" },
-          "502": { "description": "Solana evidence provider unavailable" }
+          "400": {
+            "description": "Invalid JSON request body",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "Transaction not found at finalized commitment",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "413": {
+            "description": "Request body exceeds 4 KB",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "415": {
+            "description": "Content-Type must be application/json",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "422": {
+            "description": "Request fields or transaction signature are invalid",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "502": {
+            "description": "Solana evidence provider unavailable",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "503": {
+            "description": "Transaction evidence or paid access is temporarily unavailable",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
         },
         "x-payment-info": {
           "price": { "mode": "fixed", "currency": "USD", "amount": "0.050000" },
@@ -65,6 +131,216 @@
             "type": "string",
             "description": "Solana transaction signature to inspect at finalized commitment."
           }
+        }
+      },
+      "TransactionEvidenceResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "network",
+          "signature",
+          "status",
+          "slot",
+          "block_time",
+          "fee_lamports",
+          "fee_sol",
+          "signers",
+          "program_ids",
+          "native_balance_changes",
+          "token_balance_changes",
+          "parsed_transfers",
+          "warnings",
+          "boundary"
+        ],
+        "properties": {
+          "network": {
+            "type": "string",
+            "const": "solana:mainnet",
+            "description": "Solana network on which the finalized transaction was observed."
+          },
+          "signature": {
+            "type": "string",
+            "description": "Transaction signature supplied in the request."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["finalized_success", "finalized_failed"],
+            "description": "Finalized execution outcome. A failed transaction can still contain a fee balance change."
+          },
+          "slot": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Finalized Solana slot containing the transaction."
+          },
+          "block_time": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "UTC block timestamp when supplied by the Solana RPC response."
+          },
+          "fee_lamports": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Transaction fee in lamports."
+          },
+          "fee_sol": {
+            "type": "string",
+            "pattern": "^[0-9]+(?:\\.[0-9]+)?$",
+            "description": "Transaction fee in SOL as an exact decimal string."
+          },
+          "signers": {
+            "type": "array",
+            "description": "Public keys marked as transaction signers.",
+            "items": { "type": "string" }
+          },
+          "program_ids": {
+            "type": "array",
+            "description": "Distinct invoked Solana program IDs, sorted lexicographically.",
+            "items": { "type": "string" }
+          },
+          "native_balance_changes": {
+            "type": "array",
+            "description": "Non-zero SOL balance changes for transaction accounts, including fees.",
+            "items": { "$ref": "#/components/schemas/NativeBalanceChange" }
+          },
+          "token_balance_changes": {
+            "type": "array",
+            "description": "Non-zero token balance changes reported by the finalized transaction metadata.",
+            "items": { "$ref": "#/components/schemas/TokenBalanceChange" }
+          },
+          "parsed_transfers": {
+            "type": "array",
+            "description": "Top-level and inner transfer instructions that the Solana RPC response parsed.",
+            "items": { "$ref": "#/components/schemas/ParsedTransfer" }
+          },
+          "warnings": {
+            "type": "array",
+            "description": "Evidence limitations or transaction conditions that require caller attention.",
+            "items": { "type": "string" }
+          },
+          "boundary": {
+            "type": "string",
+            "description": "Explicit limit on what the public-chain evidence establishes."
+          }
+        }
+      },
+      "NativeBalanceChange": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["account", "pre_lamports", "post_lamports", "change_lamports", "change_sol"],
+        "properties": {
+          "account": { "type": "string", "description": "Solana account public key." },
+          "pre_lamports": { "type": "string", "pattern": "^[0-9]+$" },
+          "post_lamports": { "type": "string", "pattern": "^[0-9]+$" },
+          "change_lamports": { "type": "string", "pattern": "^-?[0-9]+$" },
+          "change_sol": {
+            "type": "string",
+            "pattern": "^-?[0-9]+(?:\\.[0-9]+)?$",
+            "description": "Signed SOL change as an exact decimal string."
+          }
+        }
+      },
+      "TokenBalanceChange": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "account",
+          "owner",
+          "mint",
+          "program_id",
+          "decimals",
+          "pre_amount",
+          "post_amount",
+          "change_amount"
+        ],
+        "properties": {
+          "account": { "type": "string", "description": "Token account public key." },
+          "owner": {
+            "type": ["string", "null"],
+            "description": "Token-account owner when supplied by the Solana RPC response."
+          },
+          "mint": { "type": "string", "description": "Token mint public key." },
+          "program_id": {
+            "type": ["string", "null"],
+            "description": "Token program ID when supplied by the Solana RPC response."
+          },
+          "decimals": { "type": "integer", "minimum": 0 },
+          "pre_amount": {
+            "type": "string",
+            "pattern": "^[0-9]+(?:\\.[0-9]+)?$",
+            "description": "Pre-transaction token amount in display units."
+          },
+          "post_amount": {
+            "type": "string",
+            "pattern": "^[0-9]+(?:\\.[0-9]+)?$",
+            "description": "Post-transaction token amount in display units."
+          },
+          "change_amount": {
+            "type": "string",
+            "pattern": "^-?[0-9]+(?:\\.[0-9]+)?$",
+            "description": "Signed token balance change in display units."
+          }
+        }
+      },
+      "ParsedTransfer": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "scope",
+          "instruction_index",
+          "parent_instruction_index",
+          "program",
+          "program_id",
+          "type",
+          "source",
+          "destination",
+          "authority",
+          "mint",
+          "amount",
+          "decimals",
+          "lamports"
+        ],
+        "properties": {
+          "scope": {
+            "type": "string",
+            "enum": ["top_level", "inner"],
+            "description": "Whether the transfer was a top-level or inner instruction."
+          },
+          "instruction_index": { "type": "integer", "minimum": 0 },
+          "parent_instruction_index": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "description": "Parent top-level instruction index for an inner instruction."
+          },
+          "program": { "type": ["string", "null"] },
+          "program_id": { "type": ["string", "null"] },
+          "type": {
+            "type": "string",
+            "enum": ["transfer", "transferChecked", "transferCheckedWithFee"]
+          },
+          "source": { "type": ["string", "null"] },
+          "destination": { "type": ["string", "null"] },
+          "authority": { "type": ["string", "null"] },
+          "mint": { "type": ["string", "null"] },
+          "amount": {
+            "type": ["string", "null"],
+            "pattern": "^[0-9]+$",
+            "description": "Raw token amount when supplied by the parsed instruction."
+          },
+          "decimals": { "type": ["integer", "null"], "minimum": 0 },
+          "lamports": {
+            "type": ["string", "null"],
+            "pattern": "^[0-9]+$",
+            "description": "Lamports transferred by a parsed native SOL instruction."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["error", "message"],
+        "properties": {
+          "error": { "type": "string", "description": "Stable machine-readable error code." },
+          "message": { "type": "string", "description": "Human-readable explanation." }
         }
       }
     }


### PR DESCRIPTION
## Summary

- add Hilt Solana Transaction Evidence as a native paid API provider
- document the 0.05 USDC per-request price and standard x402 V2 `exact` settlement on Solana mainnet
- include a co-located OpenAPI 3.1 sidecar for deterministic catalog builds
- document retry-safe request IDs, spend-aware usage, and evidence boundaries

## Validation

- `pay 0.27.0 catalog check . --changed-from origin/main --strict -v`
- 1/1 endpoint passed the Solana compatibility gate
- live paid flow passed: HTTP 402 challenge, 0.05 USDC settlement, HTTP 200 evidence response
- identical request and payment replay returned HTTP 200 without a second debit
- settlement: https://solscan.io/tx/ifT7gung5t3RXdtELnA9XgC3ZhtWvABRQyXq1u8JpGbWfPXQs4bT2zarxNLBch4NM8bCyNKi4HUJ8XtbQm7dX7y

The endpoint requires no Hilt account or API key from the buyer.