### PR TITLE
feat(provider): add covenant/mizuki - fixed-price GitHub maintenance paid over x402

### DIFF
--- a/providers/covenant/mizuki/PAY.md
+++ b/providers/covenant/mizuki/PAY.md
@@ -1,0 +1,96 @@
+---
+name: mizuki
+title: "Mizuki the Mech - fixed-price GitHub maintenance"
+description: "Fixed-price maintenance on public GitHub repositories, paid per job in Solana USDC. Returns a validated pull request or refunds the full quoted amount, with no account, subscription or prepaid balance."
+use_case: "Use when a small, clearly scoped issue in a public GitHub repository needs a real code change: a bug fix, a failing check, tests, or documentation that has drifted from the code."
+category: devtools
+service_url: https://mizuki.opencovenant.org/api/mizuki
+version: v1
+openapi:
+  path: openapi.json
+---
+
+Mizuki takes one authorized issue from a public GitHub repository and returns a
+pull request that passes the repository's own checks, or refunds the entire
+quoted payment. There is no account to create. A refund that cannot be broadcast
+yet stays visible as `refund_pending` until it settles.
+
+Pricing is fixed before payment and bound to what was quoted:
+
+- **Micro** - 2 USDC, at most 3 changed files.
+- **Standard** - 10 USDC, at most 10 changed files.
+
+`POST /v1/quotes` reads the issue and returns the price along with the x402
+challenge. The quote is pinned to the repository head it was priced against and
+is valid for 15 minutes. `POST /v1/jobs` settles it, with a caller-generated
+`idempotency-key` header. Payment is an exact USDC transfer on Solana mainnet
+with a sponsored fee payer, so a caller needs USDC but not SOL. Echo the
+challenge's `resource.url` exactly; an authorization built from any other origin
+is rejected.
+
+## Paying
+
+The 402 body and the `payment-required` header carry the same x402 v2 challenge.
+Settlement is the `exact` scheme on Solana mainnet, so a standard client handles
+it. The reference web client uses `@x402/fetch` with `ExactSvmScheme` from
+`@x402/svm/exact/client`, selecting the requirement whose `network` is
+`solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` and whose `asset` is the USDC mint
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`.
+
+Two things catch callers out:
+
+- **Send the payment to the challenge's `resource.url`, not to the base URL in
+  this listing.** The service issues that URL and rejects any authorization
+  whose resource does not match it byte for byte. It currently resolves to the
+  runtime origin rather than `mizuki.opencovenant.org`, which is expected.
+- The fee payer in `accepts[0].extra.feePayer` is sponsored, so the paying
+  wallet needs USDC but no SOL.
+
+Retry the same `POST /v1/jobs` with the `payment-signature` header and the same
+`idempotency-key`. Success is **202**, and the `payment-response` header carries
+the settlement receipt.
+
+## What it will not do
+
+Work outside the quoted scope is refused rather than attempted. Mizuki declines
+new features, new endpoints or commands, anything touching authentication,
+secrets, cryptography, wallets or payments, deployment and CI workflow changes,
+security and vulnerability work, licensing, and lockfiles, generated, vendored
+or binary files. Private repositories are out of scope entirely.
+
+Two GitHub Apps must already be installed on the target repository, and a
+maintainer with write access must have applied the `mizuki:authorized` label to
+the issue. Mizuki opens pull requests and never merges them; the maintainer
+decides. Unsolicited pull requests are never opened.
+
+## Refunds
+
+If the patch does not pass repository checks and an independent reviewer, the
+full quoted amount is returned to the original payer. Network fees are not
+deducted from the principal. Mizuki cannot execute that refund itself: a
+separately deployed policy signer holds the funds, derives the payer and amount
+from two finalized views of the chain, and is the only party that can move them.
+Retries reuse the same economic idempotency key, so a retry can never authorize
+a second transfer.
+
+Every settled job, refund and bounty is published at
+`https://mizuki.opencovenant.org/activity`.
+
+## Spend-aware usage
+
+- Quote before you pay. `POST /v1/quotes` is free and tells you the class, the
+  file cap and the exact validation commands the patch will have to pass.
+- One issue per job. The request takes a single issue URL, and an issue whose
+  body bundles several unrelated changes is refused as out of scope.
+- Check the issue has the `mizuki:authorized` label before quoting. Both Apps
+  must be installed before payment; a missing verifier App fails at
+  `POST /v1/jobs` rather than at the quote.
+- Reuse your `idempotency-key` when retrying `POST /v1/jobs`. A fresh key on a
+  retry risks reserving a second job against the same work.
+- A quote expires after 15 minutes and is invalidated early if the repository
+  head moves. Re-quote rather than paying a stale one; a moved head returns 409
+  and charges nothing.
+- Prefer Micro. If the work genuinely needs more than 3 files it will be classed
+  Standard automatically, so paying for Standard up front buys nothing.
+- Quote requests are rate limited per source. Back off on a 429 rather than
+  retrying immediately.

--- a/providers/covenant/mizuki/PAY.md
+++ b/providers/covenant/mizuki/PAY.md
@@ -28,6 +28,13 @@ with a sponsored fee payer, so a caller needs USDC but not SOL. Echo the
 challenge's `resource.url` exactly; an authorization built from any other origin
 is rejected.
 
+## Checking a repository first
+
+`GET /x402/assess/{owner}/{repo}` reports whether a repository qualifies and which
+command Mizuki would run to validate a change, for 0.001 USDC. It reads the
+repository's root manifests. It is not a quote and reserves nothing, so it is the
+cheap way to find out whether a repository is worth quoting at all.
+
 ## Paying
 
 The 402 body and the `payment-required` header carry the same x402 v2 challenge.

--- a/providers/covenant/mizuki/openapi.json
+++ b/providers/covenant/mizuki/openapi.json
@@ -308,6 +308,109 @@
           }
         }
       }
+    },
+    "/x402/assess/{owner}/{repo}": {
+      "get": {
+        "operationId": "assessRepository",
+        "summary": "Check whether a repository qualifies for Mizuki maintenance",
+        "description": "Reports whether a public GitHub repository qualifies for Mizuki maintenance and which command Mizuki would run to validate a change. This reads the repository's root manifests. It is not a quote and reserves nothing.",
+        "parameters": [
+          {
+            "name": "owner",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "GitHub owner or organisation",
+            "example": "open-covenant"
+          },
+          {
+            "name": "repo",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "GitHub repository name",
+            "example": "covenant"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The assessment.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "repository",
+                    "observedAt",
+                    "eligible",
+                    "supportedManifests"
+                  ],
+                  "properties": {
+                    "repository": {
+                      "type": "string"
+                    },
+                    "observedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "eligible": {
+                      "type": "boolean"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "defaultBranch": {
+                      "type": "string"
+                    },
+                    "detectedManifest": {
+                      "type": "string"
+                    },
+                    "validationCommand": {
+                      "type": "string"
+                    },
+                    "supportedManifests": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "repository": "open-covenant/covenant",
+                  "observedAt": "2026-09-02T11:51:37.805Z",
+                  "eligible": true,
+                  "defaultBranch": "main",
+                  "detectedManifest": "pnpm-lock.yaml",
+                  "validationCommand": "pnpm test",
+                  "supportedManifests": [
+                    "pnpm-lock.yaml",
+                    "package-lock.json",
+                    "yarn.lock",
+                    "Cargo.toml",
+                    "pyproject.toml",
+                    "pytest.ini",
+                    "go.mod"
+                  ]
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Payment required. The body and the `payment-required` header carry the same x402 v2 challenge: 0.001 USDC on Solana mainnet, exact scheme, with a sponsored fee payer."
+          },
+          "404": {
+            "description": "The repository does not exist or is not public."
+          },
+          "503": {
+            "description": "GitHub is unavailable or rate limited."
+          }
+        }
+      }
     }
   },
   "components": {

--- a/providers/covenant/mizuki/openapi.json
+++ b/providers/covenant/mizuki/openapi.json
@@ -1,0 +1,800 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Mizuki the Mech",
+    "version": "v1",
+    "description": "Fixed-price software maintenance on public GitHub repositories, settled per job in USDC over x402. A quote is pinned to the repository revision it was priced against. A settled job resolves to a validated pull request or a full refund of the quoted amount.",
+    "license": {
+      "name": "Proprietary service"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://mizuki.opencovenant.org/api/mizuki"
+    }
+  ],
+  "paths": {
+    "/v1/quotes": {
+      "post": {
+        "operationId": "createQuote",
+        "summary": "Create a fixed quote for one authorized public GitHub issue",
+        "description": "Reads the issue and repository metadata and returns a fixed quote plus the x402 challenge used to pay for it. Creates no branch and no pull request. The repository must have both Mizuki GitHub Apps installed and a maintainer must have applied the mizuki:authorized label to the issue.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "github_issue_url"
+                ],
+                "properties": {
+                  "github_issue_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Public GitHub issue URL, e.g. https://github.com/owner/repo/issues/123"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Quote issued. Valid for 15 minutes and pinned to baseSha.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Quote"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "description": "The Mizuki GitHub App is not installed on this repository, or the repository is private.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The URL is not a canonical public GitHub issue URL.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The issue is outside the maintenance-only scope, or too large for the class.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "description": "The issue could not be read, or it is missing the maintainer authorization label.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Paid intake is closed by the operator.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/jobs": {
+      "post": {
+        "operationId": "submitJob",
+        "summary": "Pay a quote and start the maintenance job",
+        "description": "Call without a payment-signature to receive the 402 challenge; retry with the authorization to settle. A paying call must carry an idempotency-key, and replaying that key returns the same job rather than starting a second one. Before accepting payment the service re-checks the App installation, the authorization label, the exact issue text and the repository head; if any of them moved since the quote it returns 409 and nothing is charged.",
+        "parameters": [
+          {
+            "name": "idempotency-key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 128
+            },
+            "description": "Caller-generated key, at most 128 characters. Replaying it returns the same job rather than starting a second one."
+          },
+          {
+            "name": "payment-signature",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "x402 v2 payment authorization for the quote. Omit it to receive the 402 challenge."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "quote_id"
+                ],
+                "properties": {
+                  "quote_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The idempotency key or quote already has a reserved job.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Payment settled; the job is reserved and work has started.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            },
+            "headers": {
+              "payment-response": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Base64url-encoded settlement receipt."
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "402": {
+            "description": "Payment required. The body is an x402 v2 challenge.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentChallenge"
+                }
+              }
+            },
+            "headers": {
+              "payment-required": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Base64url-encoded x402 v2 challenge, the same document as the body."
+              }
+            }
+          },
+          "403": {
+            "description": "The App installation or authorization re-check failed at payment time.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Quote not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The quote expired, the repository moved since it was priced, or the idempotency key was already used for a different quote. Nothing is charged.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The issue moved outside the maintenance-only scope since the quote.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "description": "The pre-payment re-check could not be completed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Intake is paused, refund capacity is unavailable, or a dependency is not ready.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/jobs/{id}": {
+      "get": {
+        "operationId": "getJob",
+        "summary": "Fetch job state, delivery evidence, or refund",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current job record.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Job"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No job with that id, or the id is not a UUID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "BadRequest": {
+        "description": "Malformed request.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Per-source token bucket exhausted.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
+      "Quote": {
+        "type": "object",
+        "description": "A fixed price bound to one issue at one repository revision.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "issueUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "issueNumber": {
+            "type": "integer"
+          },
+          "issueTitle": {
+            "type": "string"
+          },
+          "baseSha": {
+            "type": "string",
+            "description": "Repository head the quote is pinned to."
+          },
+          "defaultBranch": {
+            "type": "string"
+          },
+          "class": {
+            "type": "string",
+            "enum": [
+              "micro",
+              "standard"
+            ]
+          },
+          "priceAtomic": {
+            "type": "string",
+            "description": "USDC in atomic units. 2000000 for micro, 10000000 for standard."
+          },
+          "maxFiles": {
+            "type": "integer",
+            "description": "3 for micro, 10 for standard."
+          },
+          "validationCommands": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Repository checks the delivered patch must pass."
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "authorizationReceipt": {
+            "type": "object",
+            "description": "Evidence that a maintainer with write access authorized this issue.",
+            "properties": {
+              "label": {
+                "type": "string"
+              },
+              "actorLogin": {
+                "type": "string"
+              },
+              "permission": {
+                "type": "string",
+                "enum": [
+                  "triage",
+                  "write",
+                  "maintain",
+                  "admin"
+                ]
+              },
+              "authorizedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "evidenceHash": {
+                "type": "string"
+              },
+              "actorId": {
+                "type": "string"
+              },
+              "verifiedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "payment": {
+            "$ref": "#/components/schemas/PaymentChallenge"
+          },
+          "issueBody": {
+            "type": "string"
+          },
+          "installationId": {
+            "type": "integer"
+          },
+          "maxCostUsd": {
+            "type": "number",
+            "description": "Execution-cost ceiling for the class. 0.8 for micro, 4 for standard."
+          }
+        },
+        "required": [
+          "id",
+          "class",
+          "priceAtomic",
+          "maxFiles",
+          "expiresAt",
+          "payment"
+        ]
+      },
+      "PaymentChallenge": {
+        "type": "object",
+        "description": "x402 v2 challenge. Exact-amount USDC transfer on Solana mainnet with a sponsored fee payer.",
+        "properties": {
+          "x402Version": {
+            "type": "integer",
+            "const": 2
+          },
+          "error": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "format": "uri",
+                "description": "Echo this value exactly when constructing the payment authorization. The service issues it and rejects any authorization whose resource does not match, so do not rebuild it from the documented base URL."
+              },
+              "description": {
+                "type": "string"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "serviceName": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "accepts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "scheme": {
+                  "type": "string",
+                  "const": "exact"
+                },
+                "network": {
+                  "type": "string",
+                  "description": "CAIP-2 chain id for Solana mainnet."
+                },
+                "amount": {
+                  "type": "string",
+                  "description": "Atomic units of the asset."
+                },
+                "asset": {
+                  "type": "string",
+                  "description": "USDC mint address."
+                },
+                "payTo": {
+                  "type": "string"
+                },
+                "maxTimeoutSeconds": {
+                  "type": "integer"
+                },
+                "extra": {
+                  "type": "object",
+                  "properties": {
+                    "description": {
+                      "type": "string"
+                    },
+                    "feePayer": {
+                      "type": "string",
+                      "description": "Sponsored fee payer; the caller does not need SOL."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why a presented authorization was rejected. Absent on a first unpaid call."
+          }
+        },
+        "required": [
+          "x402Version",
+          "accepts"
+        ]
+      },
+      "Job": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "settlement_pending",
+              "paid",
+              "admitted",
+              "running",
+              "validating",
+              "delivered",
+              "rejected",
+              "failed",
+              "refund_pending",
+              "refunded"
+            ]
+          },
+          "issueUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "issueTitle": {
+            "type": "string"
+          },
+          "class": {
+            "type": "string",
+            "enum": [
+              "micro",
+              "standard"
+            ]
+          },
+          "priceAtomic": {
+            "type": "string"
+          },
+          "paymentTransaction": {
+            "type": "string",
+            "description": "Solana signature for the settled payment."
+          },
+          "prUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Present once a pull request is opened."
+          },
+          "mergedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "refundTransaction": {
+            "type": "string",
+            "description": "Solana signature returning the full quoted amount."
+          },
+          "changedFiles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "validations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "exitCode": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "error": {
+            "type": "string",
+            "description": "Why the attempt stopped, when it did."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deliveryEvidence": {
+            "type": "object",
+            "description": "Proof of what was published, recorded when the pull request opens.",
+            "properties": {
+              "pullRequestNumber": {
+                "type": "integer"
+              },
+              "headSha": {
+                "type": "string"
+              },
+              "baseSha": {
+                "type": "string"
+              },
+              "baseRef": {
+                "type": "string"
+              },
+              "diffHash": {
+                "type": "string"
+              },
+              "observedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "refundLiabilityDischarge": {
+            "type": "object",
+            "description": "Set once the policy signer verifies the merge and releases the refund reserve.",
+            "properties": {
+              "dischargedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "evidenceHash": {
+                "type": "string"
+              }
+            }
+          },
+          "review": {
+            "type": "object",
+            "description": "Verdict of the separate reviewer that never saw the first attempt.",
+            "properties": {
+              "approved": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "reviewedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "artifactHash": {
+                "type": "string"
+              },
+              "provider": {
+                "$ref": "#/components/schemas/ProviderReceipt"
+              }
+            }
+          },
+          "reviewAttempts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "phase": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "received",
+                    "completed",
+                    "failed"
+                  ]
+                },
+                "artifactHash": {
+                  "type": "string"
+                },
+                "reviewedAt": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "costUsd": {
+                  "type": "number"
+                },
+                "inputTokens": {
+                  "type": "integer"
+                },
+                "outputTokens": {
+                  "type": "integer"
+                },
+                "approved": {
+                  "type": "boolean"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "provider": {
+                  "$ref": "#/components/schemas/ProviderReceipt"
+                }
+              }
+            }
+          },
+          "variableRouteCostEstimateUsd": {
+            "type": "number",
+            "description": "Recorded model and sandbox cost for this job."
+          },
+          "costCoverage": {
+            "type": "object",
+            "description": "Which cost categories the estimate includes and which it omits.",
+            "properties": {
+              "included": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "excluded": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "state",
+          "issueUrl",
+          "class",
+          "priceAtomic",
+          "changedFiles",
+          "validations"
+        ]
+      },
+      "ProviderReceipt": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "route": {
+            "type": "string",
+            "const": "marketplace"
+          },
+          "providerId": {
+            "type": "string"
+          },
+          "requestId": {
+            "type": "string"
+          },
+          "costMicrounits": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds `covenant/mizuki`, a fixed-price software-maintenance service for public GitHub repositories, settled per job in USDC over x402.

A caller hands it one authorized GitHub issue. It returns a quote pinned to the repository revision it was priced against, and a settled job resolves to a validated pull request or a full refund of the quoted amount. Micro is 2 USDC for at most 3 changed files, Standard is 10 USDC for at most 10.

`category: devtools`. Settlement is the `exact` scheme on Solana mainnet with a sponsored fee payer, so a paying wallet needs USDC but no SOL.

### Verification

`catalog check` passes with the CI invocation:

```
pay catalog check . --files providers/covenant/mizuki/PAY.md \
  --currencies USDC,USDT --probe-timeout 15 --probe-concurrency 5
```

The three probe failures are expected. The probe asserts 402 on every endpoint; only `POST /v1/jobs` is payment-gated. `POST /v1/quotes` is free by design, because a caller should be able to see the price and the exact validation commands before paying, and `GET /v1/jobs/{id}` is a public read.

Every status code, field name and enum in the committed spec was checked against the live service rather than written from the source alone. A separate cold-read pass then worked through the listing with no other context and confirmed the happy path end to end: the quote response and both job records diff clean against `components/schemas` with no undocumented fields.

### Notes for reviewers

The x402 challenge issues a `resource.url` on the runtime origin rather than the `service_url` domain. That is deliberate. The service verifies a payment authorization against that exact value, so callers must echo it rather than rebuild it from the base URL. Both the spec description and PAY.md say so explicitly.

`Retry-After` is set by the origin but not forwarded by the proxy at the documented base, so the listing does not promise it.
