### PR TITLE
chore(vybenetwork/solana-analytics): sync spec — drop deprecated endpoints, fix stale prices

### DIFF
--- a/providers/vybenetwork/solana-analytics/openapi.json
+++ b/providers/vybenetwork/solana-analytics/openapi.json
@@ -8242,14 +8242,14 @@
       "email": "info@vybenetwork.com",
       "name": "Vybe Dev Team"
     },
-    "description": "Read access to Solana on-chain data — tokens, wallets, markets, prices, trades, transfers, NFTs. No API key, no signup. Pay in USDC per request with the x402 protocol; the per-route price is declared in `x-payment-info`. WebSocket streaming uses prepaid credits.",
+    "description": "Read access to Solana on-chain data — tokens, wallets, markets, prices, trades, transfers. No API key, no signup. Pay in USDC per request with the x402 protocol; the per-route price is declared in `x-payment-info`. WebSocket streaming uses prepaid credits.",
     "license": {
       "name": "Terms of Service",
       "url": "https://alpha.vybenetwork.com/terms"
     },
     "title": "Vybe Solana Analytics API (x402)",
     "version": "3.28.21",
-    "x-guidance": "Fastest path: install the official client `@vybenetwork/x402-client` (https://github.com/vybenetwork/x402-client) — it handles 402 challenges, USDC signing, and WebSocket session/credit management for you. Manual flow: call any /v4/* endpoint without auth to receive a 402 challenge describing the USDC amount, asset, network, and recipient; sign the transfer with any x402 client (e.g. x402-axios) and retry with the `payment-signature` header to receive the response. For WebSocket streaming, POST /api/sessions with an x402 payment to receive a JWT session token + 1000 credits, then connect to /ws?token=<jwt>; each inbound event debits 1 credit and the session auto-tops up when the balance gets low.",
+    "x-guidance": "Fastest path: install the official client `@vybenetwork/x402-client` (https://github.com/vybenetwork/x402-client) — it handles 402 challenges, USDC signing, and WebSocket session/credit management for you. Manual flow: call any /v4/* endpoint without auth to receive a 402 challenge describing the USDC amount, asset, network, and recipient; sign the transfer with any x402 client (e.g. x402-axios) and retry with the `payment-signature` header to receive the response. For WebSocket streaming, POST /api/sessions with an x402 payment to receive a JWT session token and a prepaid credit balance, then connect to /live?jwt=<jwt>; opening the socket and each inbound event debit credits (see connectionCost/eventCost at GET /api/pricing). When the balance runs low, the client tops up with another x402 payment to POST /api/sessions/{id}/topup.",
     "x-client-sdk": {
       "npm": "@vybenetwork/x402-client",
       "repository": "https://github.com/vybenetwork/x402-client"
@@ -8390,7 +8390,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -8529,7 +8529,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -8708,7 +8708,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.009000"
+            "amount": "0.015000"
           },
           "protocols": [
             {
@@ -8800,7 +8800,7 @@
     },
     "/v4/oracle/pyth/pricefeeds": {
       "get": {
-        "description": "**Replaces**: `GET /price/pyth-accounts`\n\nLists all Pyth price feeds with their product accounts and symbols.",
+        "description": "Solana API endpoint for fetching available Pyth price product pairs on Solana. Discover all available Pyth price feeds and their associated product accounts.",
         "operationId": "get_pyth_price_product_pairs_v4",
         "parameters": [
           {
@@ -8857,7 +8857,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -9039,11 +9039,12 @@
         "tags": [
           "Oracle (Pyth)"
         ],
+        "description": "Solana API endpoint for fetching historical OHLC data from Pyth oracle price feeds. Get open, high, low, close prices for any Pyth price feed account.",
         "x-payment-info": {
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.009000"
+            "amount": "0.015000"
           },
           "protocols": [
             {
@@ -9121,7 +9122,7 @@
     },
     "/v4/oracle/pyth/pricefeeds/{priceFeedAddress}/price": {
       "get": {
-        "description": "**Replaces**: `GET /price/{priceFeedId}/pyth-price`\n\nReturns current price from a Pyth oracle feed.",
+        "description": "Solana API endpoint for fetching the current Pyth oracle price for any price feed on Solana. Returns price, confidence interval, and EMAP data in real-time.",
         "operationId": "get_pyth_price_v4",
         "parameters": [
           {
@@ -9188,7 +9189,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -9224,7 +9225,7 @@
     },
     "/v4/oracle/pyth/pricefeeds/{priceFeedAddress}/price-ts": {
       "get": {
-        "description": "**Replaces**: `GET /price/{priceFeedId}/pyth-price-ts`\n\nReturns historical price data from a Pyth oracle feed.",
+        "description": "Solana API endpoint for fetching Pyth oracle price time series data on Solana. Get historical price snapshots with confidence intervals for any Pyth price feed.",
         "operationId": "get_pyth_price_ts_v4",
         "parameters": [
           {
@@ -9354,7 +9355,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -9428,7 +9429,7 @@
     },
     "/v4/oracle/pyth/products/{productAddress}": {
       "get": {
-        "description": "**Replaces**: `GET /price/{productId}/pyth-product`\n\nReturns metadata for a Pyth product by its ID.",
+        "description": "Solana API endpoint for fetching Pyth product metadata on Solana. Get product account details, asset type, and associated price feed accounts.",
         "operationId": "get_pyth_product_v4",
         "parameters": [
           {
@@ -9495,7 +9496,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -9667,7 +9668,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -9764,7 +9765,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -9894,7 +9895,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -10069,7 +10070,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -10198,7 +10199,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -10377,7 +10378,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.009000"
+            "amount": "0.015000"
           },
           "protocols": [
             {
@@ -10596,7 +10597,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -10723,7 +10724,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -10750,235 +10751,6 @@
                 },
                 "output": {
                   "$ref": "#/components/schemas/TokenLiquidity"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v4/tokens/{mintAddress}/markets-ts": {
-      "get": {
-        "description": "Returns trade activity for each market (trading pair) that involves a given token, bucketed over time.\nEach data point contains the market's mint address, a timestamp, and the aggregated trade activity for that period.\nSupports daily (1d), weekly (7d), and monthly (30d) resolutions, and optionally filters to a single market.\nDefaults to daily resolution ('1d') over the last 24 hours with up to 1000 data points.\n\nUse this to compare how a token performs across different markets over time — for example,\nto see whether volume shifted from one DEX pool to another.",
-        "operationId": "get_token_markets_timeseries_v4",
-        "parameters": [
-          {
-            "description": "The mint address of the token.",
-            "in": "path",
-            "name": "mintAddress",
-            "required": true,
-            "schema": {
-              "format": "pubkey",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optional market address to restrict results to a single trading pair. If omitted, all markets for the token are returned.",
-            "in": "query",
-            "name": "marketId",
-            "required": false,
-            "schema": {
-              "allOf": [
-                {
-                  "format": "pubkey",
-                  "type": "string"
-                }
-              ],
-              "nullable": true
-            }
-          },
-          {
-            "description": "Time bucket size. Possible values: '1d' (daily), '7d' (weekly), '30d' (monthly). Defaults to '1d'.",
-            "in": "query",
-            "name": "resolution",
-            "required": false,
-            "schema": {
-              "allOf": [
-                {
-                  "description": "Represents the supported time-window resolutions for account/PnL queries.",
-                  "enum": [
-                    "1d",
-                    "7d",
-                    "30d"
-                  ],
-                  "type": "string"
-                }
-              ],
-              "nullable": true
-            }
-          },
-          {
-            "description": "Maximum number of data points to return. Defaults to 1000.",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "format": "int32",
-              "minimum": 0,
-              "nullable": true,
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Page number to return (zero-indexed). Defaults to 0.",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "format": "int32",
-              "minimum": 0,
-              "nullable": true,
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Start of the time range (unix timestamp, seconds). Defaults to 24 hours ago.",
-            "in": "query",
-            "name": "timeStart",
-            "required": false,
-            "schema": {
-              "format": "int64",
-              "minimum": 0,
-              "nullable": true,
-              "type": "integer"
-            }
-          },
-          {
-            "description": "End of the time range (unix timestamp, seconds). Defaults to the current time.",
-            "in": "query",
-            "name": "timeEnd",
-            "required": false,
-            "schema": {
-              "format": "int64",
-              "minimum": 0,
-              "nullable": true,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TokenMarketTimeseriesResponse"
-                }
-              }
-            },
-            "description": "Array of per-market data points with mint address, timestamp, and aggregated trade activity."
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            },
-            "description": "Invalid parameters — check that `resolution` is one of '1d', '7d', '30d', and that `timeStart` < `timeEnd` if provided."
-          },
-          "402": {
-            "description": "Payment Required"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            },
-            "description": "Unexpected server error. The response body includes an `id` field — provide this when contacting support."
-          }
-        },
-        "summary": "Get DEX market history for a Solana token",
-        "tags": [
-          "Tokens"
-        ],
-        "x-payment-info": {
-          "price": {
-            "mode": "fixed",
-            "currency": "USD",
-            "amount": "0.003000"
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        },
-        "x-extensions": {
-          "bazaar": {
-            "schema": {
-              "properties": {
-                "input": {
-                  "type": "object",
-                  "properties": {
-                    "mintAddress": {
-                      "format": "pubkey",
-                      "type": "string",
-                      "description": "The mint address of the token."
-                    },
-                    "marketId": {
-                      "allOf": [
-                        {
-                          "format": "pubkey",
-                          "type": "string"
-                        }
-                      ],
-                      "nullable": true,
-                      "description": "Optional market address to restrict results to a single trading pair. If omitted, all markets for the token are returned."
-                    },
-                    "resolution": {
-                      "allOf": [
-                        {
-                          "description": "Represents the supported time-window resolutions for account/PnL queries.",
-                          "enum": [
-                            "1d",
-                            "7d",
-                            "30d"
-                          ],
-                          "type": "string"
-                        }
-                      ],
-                      "nullable": true,
-                      "description": "Time bucket size. Possible values: '1d' (daily), '7d' (weekly), '30d' (monthly). Defaults to '1d'."
-                    },
-                    "limit": {
-                      "format": "int32",
-                      "minimum": 0,
-                      "nullable": true,
-                      "type": "integer",
-                      "description": "Maximum number of data points to return. Defaults to 1000."
-                    },
-                    "page": {
-                      "format": "int32",
-                      "minimum": 0,
-                      "nullable": true,
-                      "type": "integer",
-                      "description": "Page number to return (zero-indexed). Defaults to 0."
-                    },
-                    "timeStart": {
-                      "format": "int64",
-                      "minimum": 0,
-                      "nullable": true,
-                      "type": "integer",
-                      "description": "Start of the time range (unix timestamp, seconds). Defaults to 24 hours ago."
-                    },
-                    "timeEnd": {
-                      "format": "int64",
-                      "minimum": 0,
-                      "nullable": true,
-                      "type": "integer",
-                      "description": "End of the time range (unix timestamp, seconds). Defaults to the current time."
-                    }
-                  },
-                  "required": [
-                    "mintAddress"
-                  ]
-                },
-                "output": {
-                  "$ref": "#/components/schemas/TokenMarketTimeseriesResponse"
                 }
               }
             }
@@ -11280,7 +11052,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -11452,7 +11224,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -11677,7 +11449,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -12157,7 +11929,7 @@
     },
     "/v4/trading/swap": {
       "post": {
-        "description": "Builds an unsigned swap transaction with slippage protection and fee deduction. Direct protocol integrations with Raydium, Meteora, Pumpfun, and others, with aggregator fallbacks for maximum route coverage.\n\nThis route is currently in beta and is subject to change.",
+        "description": "Solana API endpoint for building token swaps. Build and return unsigned transactions for direct swaps on DEXs like Pump.fun, Raydium and more.",
         "operationId": "do_swap_proxy",
         "requestBody": {
           "content": {
@@ -12222,7 +11994,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -12256,7 +12028,7 @@
     },
     "/v4/trading/swap-quote": {
       "get": {
-        "description": "Returns the expected output amount, swap rate, and slippage threshold for a given token pair and amount. Quotes are sourced through internal pool scanning using vetted liquidity criteria combined with external aggregators to maximize route coverage—prioritizing direct pools and vetted markets first.\n\nThis route is currently in beta and is subject to change.",
+        "description": "Solana API endpoint for fetching Solana swap quotes. Returns expected output, price impact, slippage bounds, and full route plan for any token pair.",
         "operationId": "get_swap_quote_proxy",
         "parameters": [
           {
@@ -12364,7 +12136,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -12887,7 +12659,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -12976,7 +12748,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -13001,95 +12773,6 @@
                 },
                 "output": {
                   "$ref": "#/components/schemas/EmptyAccountsResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v4/wallets/batch/nft-balances": {
-      "post": {
-        "description": "Solana API endpoint for fetching multi-wallet NFT balances with collection metadata, floor prices, and aggregated portfolio values across multiple wallets.",
-        "operationId": "post_wallet_nfts_many_v4",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AccountParamsNftsMany"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WalletBalanceNftResultsMany"
-                }
-              }
-            },
-            "description": "Successful response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            },
-            "description": "Invalid request"
-          },
-          "402": {
-            "description": "Payment Required"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            },
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Get NFT balances for multiple wallets",
-        "tags": [
-          "Wallets"
-        ],
-        "x-payment-info": {
-          "price": {
-            "mode": "fixed",
-            "currency": "USD",
-            "amount": "0.030000"
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        },
-        "x-extensions": {
-          "bazaar": {
-            "schema": {
-              "properties": {
-                "input": {
-                  "type": "object",
-                  "properties": {
-                    "body": {
-                      "$ref": "#/components/schemas/AccountParamsNftsMany"
-                    }
-                  },
-                  "required": [
-                    "body"
-                  ]
-                },
-                "output": {
-                  "$ref": "#/components/schemas/WalletBalanceNftResultsMany"
                 }
               }
             }
@@ -13154,7 +12837,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -13502,7 +13185,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -13788,7 +13471,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.015000"
+            "amount": "0.018000"
           },
           "protocols": [
             {
@@ -14008,7 +13691,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -14117,7 +13800,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -14294,7 +13977,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -14381,7 +14064,7 @@
     },
     "/v4/wallets/{ownerAddress}/defi-positions": {
       "get": {
-        "description": "Returns LP positions, lending/borrowing, staking, and yield farming across DeFi protocols.\n\nThis route is currently in beta and is subject to change.",
+        "description": "Solana API endpoint for fetching DeFi positions by wallet. Returns LP, lending, and staking data across 50+ protocols via a unified proxy endpoint.",
         "operationId": "get_defi_accounts_v4_proxy",
         "parameters": [
           {
@@ -14451,7 +14134,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -14591,7 +14274,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -14752,7 +14435,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -14803,182 +14486,6 @@
                 },
                 "output": {
                   "$ref": "#/components/schemas/EmptyAccountsResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v4/wallets/{ownerAddress}/nft-balance": {
-      "get": {
-        "description": "**Replaces**: `GET /account/nft-balance/{ownerAddress}`\n\nReturns NFT holdings with collection metadata, floor prices, and estimated USD value.",
-        "operationId": "get_wallet_nfts_v4",
-        "parameters": [
-          {
-            "description": "The public key (pubKey) associated with the Solana account.",
-            "in": "path",
-            "name": "ownerAddress",
-            "required": true,
-            "schema": {
-              "format": "pubkey",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Whether or not we should include NFTs we do not track prices for.",
-            "in": "query",
-            "name": "includeNoPriceBalance",
-            "required": false,
-            "schema": {
-              "nullable": true,
-              "type": "boolean"
-            }
-          },
-          {
-            "description": "Sort ascending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
-            "in": "query",
-            "name": "sortByAsc",
-            "required": false,
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          },
-          {
-            "description": "Sort descending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used",
-            "in": "query",
-            "name": "sortByDesc",
-            "required": false,
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          },
-          {
-            "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum).",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "format": "int32",
-              "minimum": 0,
-              "nullable": true,
-              "type": "integer"
-            }
-          },
-          {
-            "description": "The requested page.",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "format": "int32",
-              "minimum": 0,
-              "nullable": true,
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WalletBalanceNftResults"
-                }
-              }
-            },
-            "description": "Successful response"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            },
-            "description": "Invalid request"
-          },
-          "402": {
-            "description": "Payment Required"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApiError"
-                }
-              }
-            },
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Get NFT holdings for a Solana wallet",
-        "tags": [
-          "Wallets"
-        ],
-        "x-payment-info": {
-          "price": {
-            "mode": "fixed",
-            "currency": "USD",
-            "amount": "0.003000"
-          },
-          "protocols": [
-            {
-              "x402": {}
-            }
-          ]
-        },
-        "x-extensions": {
-          "bazaar": {
-            "schema": {
-              "properties": {
-                "input": {
-                  "type": "object",
-                  "properties": {
-                    "ownerAddress": {
-                      "format": "pubkey",
-                      "type": "string",
-                      "description": "The public key (pubKey) associated with the Solana account."
-                    },
-                    "includeNoPriceBalance": {
-                      "nullable": true,
-                      "type": "boolean",
-                      "description": "Whether or not we should include NFTs we do not track prices for."
-                    },
-                    "sortByAsc": {
-                      "nullable": true,
-                      "type": "string",
-                      "description": "Sort ascending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used"
-                    },
-                    "sortByDesc": {
-                      "nullable": true,
-                      "type": "string",
-                      "description": "Sort descending based on amount or value of positions. Only one of sort_by_asc or sort_by_desc can be used"
-                    },
-                    "limit": {
-                      "format": "int32",
-                      "minimum": 0,
-                      "nullable": true,
-                      "type": "integer",
-                      "description": "The limit of entries to return. If not passed, first 1000 entries are returned (the maximum)."
-                    },
-                    "page": {
-                      "format": "int32",
-                      "minimum": 0,
-                      "nullable": true,
-                      "type": "integer",
-                      "description": "The requested page."
-                    }
-                  },
-                  "required": [
-                    "ownerAddress"
-                  ]
-                },
-                "output": {
-                  "$ref": "#/components/schemas/WalletBalanceNftResults"
                 }
               }
             }
@@ -15135,7 +14642,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.015000"
+            "amount": "0.018000"
           },
           "protocols": [
             {
@@ -15312,7 +14819,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -15490,7 +14997,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -15562,7 +15069,7 @@
     },
     "/v4/wallets/{ownerAddress}/token-balance": {
       "get": {
-        "description": "**Replaces**: `GET /account/token-balance/{ownerAddress}`\n\nReturns SOL & SPL token holdings with amounts, USD values, metadata, and native stake amount for a wallet.\nA maximum of 10,000 token accounts can be requested.",
+        "description": "Solana API endpoint for fetching wallet token balances with SPL and Token-2022 assets, USD values, price changes, staking balances, and full metadata.",
         "operationId": "get_wallet_tokens_v4",
         "parameters": [
           {
@@ -15727,7 +15234,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {
@@ -15919,7 +15426,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.015000"
+            "amount": "0.018000"
           },
           "protocols": [
             {
@@ -16067,7 +15574,7 @@
           "price": {
             "mode": "fixed",
             "currency": "USD",
-            "amount": "0.003000"
+            "amount": "0.012000"
           },
           "protocols": [
             {


### PR DESCRIPTION
Resyncs our committed OpenAPI sidecar with the live gateway spec at https://x402-api.vybenetwork.xyz/openapi.json. Two kinds of drift since #117:

**1. Three endpoints were removed upstream** (Vybe deprecated the Postgres-backed routes; the gateway now answers them `410 Gone`):

- `GET /v4/wallets/{ownerAddress}/nft-balance`
- `POST /v4/wallets/batch/nft-balances`
- `GET /v4/tokens/{mintAddress}/markets-ts`

**2. Prices in `x-payment-info` were stale** — the sidecar still advertised the old $0.003 default and $0.009 OHLCV tier. Live:

| Tier | Was in sidecar | Live |
|---|---|---|
| default | $0.003 | **$0.012** |
| OHLCV candles | $0.009 | **$0.015** |
| wallet PnL / top traders | — | **$0.018** |
| top holders, transfers, trades | $0.024 | $0.024 |
| batch POST | $0.030 | $0.030 |

The `PAY.md` pricing table was already correct; only the spec lagged, so agents reading the sidecar were quoted 4x under the real default. This PR makes the two agree.

Also refreshed `info.description` (no longer claims NFT coverage) and `info.x-guidance` (WebSocket flow is `/live?jwt=` with costs discoverable at `GET /api/pricing`; the old text described a retired `/ws?token=` endpoint and a 1-credit-per-event rate).

46 → 43 paths. `PAY.md` unchanged.

## Validation

Ran the same checks CI runs, via `ghcr.io/solana-foundation/pay:latest`:

```
catalog check . --no-probe
  → Registry check passed with warnings (894 endpoints / 74 providers)
  → 0 warnings on vybenetwork/solana-analytics

catalog check . --files providers/vybenetwork/solana-analytics/PAY.md \
  --currencies USDC,USDT --probe-timeout 15 --probe-concurrency 5
  → Changed providers check successful
  → 43 endpoints tested, 43/43 gates compatible with Solana
```

| Provider | OK | Non-Solana | Tolerated 404 | Verdict |
|----------|----|------------|---------------|---------|
| `vybenetwork/solana-analytics` | 43 | 0 | 0 | ✅ pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)