### PR TITLE
Add citable/seo

### DIFF
--- a/providers/citable/seo/PAY.md
+++ b/providers/citable/seo/PAY.md
@@ -1,0 +1,43 @@
+---
+name: seo
+title: "Citable"
+description: "SEO and AI-visibility data for agents: keyword research and search volume, on-page audits, AI-citation checks across ChatGPT, Claude, Gemini and Perplexity, Google rank and SERP results, competitor keywords and backlinks."
+use_case: "Use for checking where a domain ranks on Google, which keywords are worth targeting and what they cost, whether AI answer engines cite a domain and for which prompts, and what a competitor's organic footprint and link profile look like."
+category: data
+service_url: https://citable.run
+openapi:
+  path: openapi.json
+---
+
+Seventeen paid GET endpoints covering two questions: how a site ranks in Google,
+and whether AI answer engines cite it. Keyword suggestions and metrics, on-page
+audits, rank and SERP checks, domain overview, keywords and history, backlinks,
+plus AI-citation checks run through the engines' own APIs.
+
+There is no account and no API key — the wallet is the identity. Prices run
+$0.005–$0.30 per call, settled in USDC on Solana mainnet. A 4xx or 5xx cancels
+the payment instead of settling it, so a failed call is never charged.
+
+Every 402 challenge carries the endpoint's query parameters and a sample
+response, so an agent can shape a valid call from the challenge alone. The
+service also publishes `/skill.md`, `/llms.txt` and `/.well-known/x402`.
+
+## Spend-aware usage
+
+- Expand a seed with `v1/keyword-suggest` ($0.005) first, then buy volumes for
+  the shortlist with `v1/keyword-metrics` ($0.03). Do not start at the metrics
+  endpoint with a guessed keyword list.
+- `v1/ai-visibility` is priced per engine asked ($0.05 each, $0.20 for all
+  four). Ask for one engine when the user named one; ask for all four only when
+  the question is about coverage.
+- `v1/citability-report` ($0.30) bundles the on-page audit, the AI-visibility
+  sweep and top-cited-pages. It costs less than those three bought separately —
+  prefer it when the user wants the whole picture, and the single endpoints when
+  they want one answer.
+- `v1/keyword-research` ($0.06) is `keyword-suggest` plus `keyword-ideas` plus
+  metrics in one call; cheaper than the three, but only worth it for a seed the
+  user actually cares about.
+- The AI-visibility endpoints never invent a prompt. Pass the buyer question the
+  user gave you; do not loop over prompts you generated yourself.
+- Domain endpoints are per-domain, not per-keyword. Ask for one competitor at a
+  time rather than sweeping a list.

--- a/providers/citable/seo/openapi.json
+++ b/providers/citable/seo/openapi.json
@@ -1,0 +1,1299 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Citable",
+        "version": "1.0.0",
+        "description": "Pay-per-check SEO and AI-visibility data. Every /v1 endpoint answers 402 with its price; pay in USDC on Solana via x402 and retry the same request. No Citable account or API key exists \u2014 the wallet is the identity. Errors are never charged.",
+        "contact": {
+            "url": "https://citable.run/docs",
+            "email": "hello@citable.run"
+        },
+        "x-guidance": "Call any /v1 endpoint with query parameters and no credentials. The reply is 402 with an x402 challenge in the payment-required header; pay it in USDC on Solana and retry the same URL. Prices are per call and quoted in the challenge; ai-visibility is quoted per engine asked. 4xx and 5xx cancel the payment instead of settling it, so a failed call costs nothing."
+    },
+    "servers": [
+        {
+            "url": "https://citable.run"
+        }
+    ],
+    "paths": {
+        "/v1/keyword-suggest": {
+            "get": {
+                "operationId": "keywordSuggest",
+                "summary": "Find related searches and questions for a seed keyword",
+                "description": "The phrasings real people type: autocomplete expansions and questions for a seed \u2014 deduped and ranked, no search volume.\n\nPrice: $0.005 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "seed",
+                        "in": "query",
+                        "required": true,
+                        "description": "keyword to expand (1\u201380 chars)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "lang",
+                        "in": "query",
+                        "required": false,
+                        "description": "language code, default en (id supported with localized question words)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "country",
+                        "in": "query",
+                        "required": false,
+                        "description": "country code, default us",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "depth",
+                        "in": "query",
+                        "required": false,
+                        "description": "0 seed only \u00b7 1 + questions and modifiers \u00b7 2 (default) + a\u2013z sweep",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "description": "max keywords per list, default 100, max 300",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sources",
+                        "in": "query",
+                        "required": false,
+                        "description": "comma list of google,youtube,bing (default all)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.005"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.005. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/keyword-research": {
+            "get": {
+                "operationId": "keywordResearch",
+                "summary": "Find keywords for a seed with volume and competition",
+                "description": "One seed, the whole picture: keywords and questions from autocomplete and the paid index, with volume, CPC, difficulty and intent attached.\n\nPrice: $0.06 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "seed",
+                        "in": "query",
+                        "required": true,
+                        "description": "keyword to research (1\u201380 chars)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "country",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter country code, default us",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "lang",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter language code, default en",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "description": "rows per list, 1\u2013200 (default 100)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.06"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.06. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/keyword-ideas": {
+            "get": {
+                "operationId": "keywordIdeas",
+                "summary": "Find related keywords for a seed, with volume and difficulty",
+                "description": "Keyword research with the numbers attached: every result contains your seed, and arrives with search volume, CPC, difficulty and intent.\n\nPrice: $0.05 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "seed",
+                        "in": "query",
+                        "required": true,
+                        "description": "keyword to research (1\u201380 chars)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "description": "ideas to return, 1\u2013100 (default 50)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "country",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter country code, default us",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "lang",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter language code, default en",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.05"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.05. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/keyword-metrics": {
+            "get": {
+                "operationId": "keywordMetrics",
+                "summary": "Look up search volume, CPC and competition for keywords",
+                "description": "Search volume, CPC, competition, difficulty and intent per keyword \u2014 one price for a batch of up to 20.\n\nPrice: $0.03 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "keywords",
+                        "in": "query",
+                        "required": true,
+                        "description": "comma list of 1\u201320 keywords (each \u226480 chars)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "country",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter country code, default us",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "lang",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter language code, default en",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.03"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.03. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/rank-check": {
+            "get": {
+                "operationId": "rankCheck",
+                "summary": "Check where a domain ranks on Google for a keyword",
+                "description": "Google organic position of a domain for a keyword, plus the top-10 list \u2014 from a licensed SERP feed, never scraped.\n\nPrice: $0.012 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "keyword",
+                        "in": "query",
+                        "required": true,
+                        "description": "search query (1\u2013120 chars)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to find, e.g. example.com (subdomains match)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "gl",
+                        "in": "query",
+                        "required": false,
+                        "description": "country code, default us",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "hl",
+                        "in": "query",
+                        "required": false,
+                        "description": "language code, default en",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "num",
+                        "in": "query",
+                        "required": false,
+                        "description": "results window to check, 10\u201350 (default 20)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.012"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.012. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/onpage-audit": {
+            "get": {
+                "operationId": "onpageAudit",
+                "summary": "Check one page for on-page SEO and AI citability",
+                "description": "Classic on-page SEO plus AI citability, scored 0\u2013100 with a fix for every non-passing check.\n\nPrice: $0.01 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "url",
+                        "in": "query",
+                        "required": true,
+                        "description": "absolute http(s) URL of the page to audit",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.01"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.01. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/ai-visibility": {
+            "get": {
+                "operationId": "aiVisibility",
+                "summary": "Check which sources AI answer engines cite for a question",
+                "description": "Which AI answer engines cite a domain for a prompt \u2014 and who they cite instead. Official APIs, never UI scraping.\n\nPrice: $0.05/engine per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "prompt",
+                        "in": "query",
+                        "required": true,
+                        "description": "the question a buyer would ask (3\u2013400 chars)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to look for in the citations, e.g. example.com (subdomains match)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "engines",
+                        "in": "query",
+                        "required": false,
+                        "description": "optional comma list of perplexity,gemini,openai,anthropic (default: all configured \u2014 GET /api lists them under engines_configured)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "dynamic",
+                        "currency": "USD",
+                        "min": "0.05",
+                        "max": "0.20"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.05/engine. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/top-cited-pages": {
+            "get": {
+                "operationId": "topCitedPages",
+                "summary": "List the pages of a domain that AI engines cite most",
+                "description": "Which pages of a domain AI engines cite most, from an aggregated index of AI answers.\n\nPrice: $0.22 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to inventory, e.g. example.com",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "description": "pages to return, 1\u201325 (default 10)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.22"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.22. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/cited-prompts": {
+            "get": {
+                "operationId": "citedPrompts",
+                "summary": "Find the prompts AI engines already cite a domain for",
+                "description": "The real questions AI engines already cite a domain for \u2014 with the answer snippet and the exact URL cited.\n\nPrice: $0.25 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to look up, e.g. example.com \u2014 or a competitor's",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "description": "prompts to return, 1\u201350 (default 10)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "platform",
+                        "in": "query",
+                        "required": false,
+                        "description": "chat_gpt or google (default: both)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.25"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.25. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/ai-mentions-trend": {
+            "get": {
+                "operationId": "aiMentionsTrend",
+                "summary": "List a domain's AI mentions month by month",
+                "description": "Monthly AI mentions and AI search volume for a domain, with month-over-month deltas \u2014 prompt tracking without a tracker.\n\nPrice: $0.18 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to track, e.g. example.com",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "required": false,
+                        "description": "start date yyyy-mm-dd (earlier than 2025-08-01 is clamped to it)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "to",
+                        "in": "query",
+                        "required": false,
+                        "description": "end date yyyy-mm-dd",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "platform",
+                        "in": "query",
+                        "required": false,
+                        "description": "chat_gpt or google (default: both)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.18"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.18. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/ai-share-of-voice": {
+            "get": {
+                "operationId": "aiShareOfVoice",
+                "summary": "Compare AI mention share across competing domains",
+                "description": "Who AI cites most across 2\u201310 competing domains \u2014 one price for the whole set.\n\nPrice: $0.18 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "domains",
+                        "in": "query",
+                        "required": true,
+                        "description": "comma list of 2\u201310 hostnames",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "platform",
+                        "in": "query",
+                        "required": false,
+                        "description": "chat_gpt or google (default: both)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.18"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.18. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/citability-report": {
+            "get": {
+                "operationId": "citabilityReport",
+                "summary": "Run the full citability report for a domain",
+                "description": "On-page audit + AI visibility across all engines + top cited pages, in one call. $0.30 instead of $0.43 separately.\n\nPrice: $0.30 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to report on, e.g. example.com",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "prompt",
+                        "in": "query",
+                        "required": true,
+                        "description": "the buyer question to ask the engines (3\u2013400 chars)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "description": "top cited pages to include, 1\u201325 (default 10)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.30"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.30. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/domain-overview": {
+            "get": {
+                "operationId": "domainOverview",
+                "summary": "Look up a domain's organic keywords and estimated traffic",
+                "description": "One domain's organic footprint \u2014 keywords ranked, top positions, estimated traffic and value.\n\nPrice: $0.03 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to profile, e.g. example.com",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "country",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter country code, default us",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "lang",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter language code, default en",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.03"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.03. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/domain-keywords": {
+            "get": {
+                "operationId": "domainKeywords",
+                "summary": "List the keywords a domain ranks for, with positions",
+                "description": "The keywords a domain actually ranks for \u2014 volume, CPC, position and the ranking URL, loudest first.\n\nPrice: $0.04 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to inventory, e.g. example.com \u2014 a competitor's works too",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "description": "keywords to return, 1\u2013100 (default 25)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "country",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter country code, default us",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "lang",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter language code, default en",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.04"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.04. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/domain-history": {
+            "get": {
+                "operationId": "domainHistory",
+                "summary": "List a domain's organic footprint month by month",
+                "description": "A domain's organic footprint month by month \u2014 keywords, top-10 count, traffic \u2014 with the trend.\n\nPrice: $0.03 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to track, e.g. example.com",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "months",
+                        "in": "query",
+                        "required": false,
+                        "description": "calendar months of history, 2\u201324 (default 12)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "country",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter country code, default us",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "lang",
+                        "in": "query",
+                        "required": false,
+                        "description": "2-letter language code, default en",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.03"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.03. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/serp": {
+            "get": {
+                "operationId": "serp",
+                "summary": "Fetch the Google results page for a keyword",
+                "description": "The raw Google results page \u2014 organic results with snippets, People-Also-Ask and related searches.\n\nPrice: $0.008 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "keyword",
+                        "in": "query",
+                        "required": true,
+                        "description": "search query (1\u2013120 chars)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "gl",
+                        "in": "query",
+                        "required": false,
+                        "description": "country code, default us",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "hl",
+                        "in": "query",
+                        "required": false,
+                        "description": "language code, default en",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "num",
+                        "in": "query",
+                        "required": false,
+                        "description": "results depth, 10\u201350 (default 10)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.008"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.008. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        },
+        "/v1/backlinks": {
+            "get": {
+                "operationId": "backlinks",
+                "summary": "Look up a domain's backlinks and referring domains",
+                "description": "Link profile in one call: totals, domain rank, broken links, and the top referring domains.\n\nPrice: $0.10 per call, paid via x402 (USDC on solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp).",
+                "parameters": [
+                    {
+                        "name": "domain",
+                        "in": "query",
+                        "required": true,
+                        "description": "hostname to profile, e.g. example.com",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "description": "referring domains to return, 1\u201325 (default 10)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "security": [],
+                "x-payment-info": {
+                    "price": {
+                        "mode": "fixed",
+                        "currency": "USD",
+                        "amount": "0.10"
+                    },
+                    "protocols": [
+                        {
+                            "x402": {
+                                "version": 2,
+                                "scheme": "exact",
+                                "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                                "asset": "USDC",
+                                "payTo": "6nWrWRTqrqpqbu5MsMW8mPDpZjKLwPb9Wf8BdMwNMWzK"
+                            }
+                        }
+                    ]
+                },
+                "responses": {
+                    "200": {
+                        "description": "The check result as JSON.",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid parameters \u2014 not charged."
+                    },
+                    "402": {
+                        "description": "Payment required \u2014 $0.10. The payment-required header carries the challenge."
+                    },
+                    "502": {
+                        "description": "Upstream data source failed \u2014 not charged."
+                    }
+                }
+            }
+        }
+    }
+}

--- a/providers/citable/seo/openapi.json
+++ b/providers/citable/seo/openapi.json
@@ -100,7 +100,200 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "seed": {
+                                            "type": "string"
+                                        },
+                                        "lang": {
+                                            "type": "string"
+                                        },
+                                        "country": {
+                                            "type": "string"
+                                        },
+                                        "depth": {
+                                            "type": "integer"
+                                        },
+                                        "suggestions": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "keyword": {
+                                                        "type": "string"
+                                                    },
+                                                    "score": {},
+                                                    "sources": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": {
+                                                        "type": "string"
+                                                    },
+                                                    "matchesSeed": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "questions": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "keyword": {
+                                                        "type": "string"
+                                                    },
+                                                    "score": {},
+                                                    "sources": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": {
+                                                        "type": "string"
+                                                    },
+                                                    "matchesSeed": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "counts": {
+                                            "type": "object",
+                                            "properties": {
+                                                "suggestions": {
+                                                    "type": "integer"
+                                                },
+                                                "questions": {
+                                                    "type": "integer"
+                                                },
+                                                "requests": {
+                                                    "type": "integer"
+                                                },
+                                                "cacheHits": {
+                                                    "type": "integer"
+                                                },
+                                                "failed": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "sources": {
+                                            "type": "object",
+                                            "properties": {
+                                                "google": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "ok": {
+                                                            "type": "integer"
+                                                        },
+                                                        "failed": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "youtube": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "ok": {
+                                                            "type": "integer"
+                                                        },
+                                                        "failed": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "bing": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "ok": {
+                                                            "type": "integer"
+                                                        },
+                                                        "failed": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "fetchedAt": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "seed": "solana rpc",
+                                    "lang": "en",
+                                    "country": "us",
+                                    "depth": 1,
+                                    "suggestions": [
+                                        {
+                                            "keyword": "solana rpc url",
+                                            "score": 1,
+                                            "sources": [
+                                                "google"
+                                            ],
+                                            "type": "expansion",
+                                            "matchesSeed": true
+                                        }
+                                    ],
+                                    "questions": [
+                                        {
+                                            "keyword": "is solana rpc free",
+                                            "score": 1,
+                                            "sources": [
+                                                "google"
+                                            ],
+                                            "type": "question",
+                                            "matchesSeed": true
+                                        }
+                                    ],
+                                    "counts": {
+                                        "suggestions": 8,
+                                        "questions": 8,
+                                        "requests": 29,
+                                        "cacheHits": 0,
+                                        "failed": 0
+                                    },
+                                    "sources": {
+                                        "google": {
+                                            "ok": 27,
+                                            "failed": 0
+                                        },
+                                        "youtube": {
+                                            "ok": 1,
+                                            "failed": 0
+                                        },
+                                        "bing": {
+                                            "ok": 1,
+                                            "failed": 0
+                                        }
+                                    },
+                                    "fetchedAt": "2026-08-24T20:43:12.919Z",
+                                    "price": "$0.005",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -181,7 +374,164 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "seed": {
+                                            "type": "string"
+                                        },
+                                        "country": {
+                                            "type": "string"
+                                        },
+                                        "lang": {
+                                            "type": "string"
+                                        },
+                                        "keywords": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "keyword": {
+                                                        "type": "string"
+                                                    },
+                                                    "volume": {
+                                                        "type": "integer"
+                                                    },
+                                                    "cpc": {},
+                                                    "competition": {},
+                                                    "difficulty": {
+                                                        "type": "integer"
+                                                    },
+                                                    "intent": {
+                                                        "type": "string"
+                                                    },
+                                                    "sources": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "isQuestion": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "questions": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "keyword": {
+                                                        "type": "string"
+                                                    },
+                                                    "volume": {
+                                                        "type": "integer"
+                                                    },
+                                                    "cpc": {},
+                                                    "competition": {},
+                                                    "difficulty": {},
+                                                    "intent": {},
+                                                    "sources": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "isQuestion": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "summary": {
+                                            "type": "object",
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer"
+                                                },
+                                                "withVolume": {
+                                                    "type": "integer"
+                                                },
+                                                "questions": {
+                                                    "type": "integer"
+                                                },
+                                                "totalFoundForSeed": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "sources": {
+                                            "type": "object",
+                                            "properties": {
+                                                "index": {
+                                                    "type": "boolean"
+                                                },
+                                                "autocomplete": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "seed": "reksadana",
+                                    "country": "id",
+                                    "lang": "id",
+                                    "keywords": [
+                                        {
+                                            "keyword": "reksadana",
+                                            "volume": 74000,
+                                            "cpc": 0.18,
+                                            "competition": "low",
+                                            "difficulty": 41,
+                                            "intent": "informational",
+                                            "sources": [
+                                                "index"
+                                            ],
+                                            "isQuestion": false
+                                        }
+                                    ],
+                                    "questions": [
+                                        {
+                                            "keyword": "apa itu reksadana",
+                                            "volume": 8100,
+                                            "cpc": 0.11,
+                                            "competition": "low",
+                                            "difficulty": 22,
+                                            "intent": "informational",
+                                            "sources": [
+                                                "index"
+                                            ],
+                                            "isQuestion": true
+                                        }
+                                    ],
+                                    "summary": {
+                                        "total": 128,
+                                        "withVolume": 104,
+                                        "questions": 23,
+                                        "totalFoundForSeed": 1840
+                                    },
+                                    "sources": {
+                                        "index": true,
+                                        "autocomplete": true
+                                    },
+                                    "price": "$0.06",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -262,7 +612,81 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "seed": {
+                                            "type": "string"
+                                        },
+                                        "country": {
+                                            "type": "string"
+                                        },
+                                        "lang": {
+                                            "type": "string"
+                                        },
+                                        "keywords": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "keyword": {
+                                                        "type": "string"
+                                                    },
+                                                    "volume": {
+                                                        "type": "integer"
+                                                    },
+                                                    "cpc": {
+                                                        "type": "number"
+                                                    },
+                                                    "competition": {
+                                                        "type": "string"
+                                                    },
+                                                    "difficulty": {
+                                                        "type": "integer"
+                                                    },
+                                                    "intent": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "totalFound": {
+                                            "type": "integer"
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "seed": "seo api",
+                                    "country": "us",
+                                    "lang": "en",
+                                    "keywords": [
+                                        {
+                                            "keyword": "seo api",
+                                            "volume": 390,
+                                            "cpc": 20.98,
+                                            "competition": "low",
+                                            "difficulty": 40,
+                                            "intent": "commercial"
+                                        }
+                                    ],
+                                    "totalFound": 1840,
+                                    "source": "dataforseo_labs",
+                                    "price": "$0.05",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -334,7 +758,81 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "keywords": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "keyword": {
+                                                        "type": "string"
+                                                    },
+                                                    "volume": {
+                                                        "type": "integer"
+                                                    },
+                                                    "cpc": {
+                                                        "type": "number"
+                                                    },
+                                                    "competition": {
+                                                        "type": "string"
+                                                    },
+                                                    "difficulty": {
+                                                        "type": "integer"
+                                                    },
+                                                    "intent": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "requested": {
+                                            "type": "integer"
+                                        },
+                                        "matched": {
+                                            "type": "integer"
+                                        },
+                                        "country": {
+                                            "type": "string"
+                                        },
+                                        "lang": {
+                                            "type": "string"
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "keywords": [
+                                        {
+                                            "keyword": "seo api",
+                                            "volume": 390,
+                                            "cpc": 20.98,
+                                            "competition": "low",
+                                            "difficulty": 40,
+                                            "intent": "commercial"
+                                        }
+                                    ],
+                                    "requested": 2,
+                                    "matched": 2,
+                                    "country": "us",
+                                    "lang": "en",
+                                    "source": "dataforseo_labs",
+                                    "price": "$0.03",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -424,7 +922,85 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "keyword": {
+                                            "type": "string"
+                                        },
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "position": {
+                                            "type": "integer"
+                                        },
+                                        "url": {
+                                            "type": "string"
+                                        },
+                                        "title": {
+                                            "type": "string"
+                                        },
+                                        "checked": {
+                                            "type": "integer"
+                                        },
+                                        "gl": {
+                                            "type": "string"
+                                        },
+                                        "hl": {
+                                            "type": "string"
+                                        },
+                                        "top10": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "position": {
+                                                        "type": "integer"
+                                                    },
+                                                    "domain": {
+                                                        "type": "string"
+                                                    },
+                                                    "url": {
+                                                        "type": "string"
+                                                    },
+                                                    "title": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "keyword": "seo api",
+                                    "domain": "dataforseo.com",
+                                    "position": 1,
+                                    "url": "https://dataforseo.com/",
+                                    "title": "DataForSEO: Powerful API Stack For Data-Driven SEO Tools",
+                                    "checked": 19,
+                                    "gl": "us",
+                                    "hl": "en",
+                                    "top10": [
+                                        {
+                                            "position": 1,
+                                            "domain": "dataforseo.com",
+                                            "url": "https://dataforseo.com/",
+                                            "title": "DataForSEO: Powerful API Stack For Data-Driven SEO Tools"
+                                        }
+                                    ],
+                                    "price": "$0.012",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -478,7 +1054,362 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "url": {
+                                            "type": "string"
+                                        },
+                                        "finalUrl": {
+                                            "type": "string"
+                                        },
+                                        "fetchedAt": {
+                                            "type": "string"
+                                        },
+                                        "http": {
+                                            "type": "object",
+                                            "properties": {
+                                                "status": {
+                                                    "type": "integer"
+                                                },
+                                                "redirects": {
+                                                    "type": "integer"
+                                                },
+                                                "contentType": {
+                                                    "type": "string"
+                                                },
+                                                "responseMs": {
+                                                    "type": "integer"
+                                                },
+                                                "bytes": {
+                                                    "type": "integer"
+                                                },
+                                                "truncated": {
+                                                    "type": "boolean"
+                                                },
+                                                "https": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "page": {
+                                            "type": "object",
+                                            "properties": {
+                                                "title": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "text": {
+                                                            "type": "string"
+                                                        },
+                                                        "length": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "metaDescription": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "text": {
+                                                            "type": "string"
+                                                        },
+                                                        "length": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "canonical": {
+                                                    "type": "string"
+                                                },
+                                                "lang": {
+                                                    "type": "string"
+                                                },
+                                                "headings": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "counts": {
+                                                            "type": "object"
+                                                        },
+                                                        "h1": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "wordCount": {
+                                                    "type": "integer"
+                                                },
+                                                "links": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "total": {
+                                                            "type": "integer"
+                                                        },
+                                                        "internal": {
+                                                            "type": "integer"
+                                                        },
+                                                        "external": {
+                                                            "type": "integer"
+                                                        },
+                                                        "nofollow": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "images": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "total": {
+                                                            "type": "integer"
+                                                        },
+                                                        "missingAlt": {
+                                                            "type": "integer"
+                                                        },
+                                                        "emptyAlt": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "structuredData": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "count": {
+                                                            "type": "integer"
+                                                        },
+                                                        "invalid": {
+                                                            "type": "integer"
+                                                        },
+                                                        "types": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            }
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "aiAccess": {
+                                            "type": "object",
+                                            "properties": {
+                                                "robotsTxt": {
+                                                    "type": "string"
+                                                },
+                                                "llmsTxt": {
+                                                    "type": "boolean"
+                                                },
+                                                "bots": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "gptbot": {
+                                                            "type": "string"
+                                                        },
+                                                        "claudebot": {
+                                                            "type": "string"
+                                                        },
+                                                        "perplexitybot": {
+                                                            "type": "string"
+                                                        },
+                                                        "google-extended": {
+                                                            "type": "string"
+                                                        },
+                                                        "ccbot": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "answerability": {
+                                            "type": "object",
+                                            "properties": {
+                                                "questionHeadings": {
+                                                    "type": "integer"
+                                                },
+                                                "hasDate": {
+                                                    "type": "boolean"
+                                                },
+                                                "hasAuthor": {
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "score": {
+                                            "type": "integer"
+                                        },
+                                        "summary": {
+                                            "type": "object",
+                                            "properties": {
+                                                "pass": {
+                                                    "type": "integer"
+                                                },
+                                                "warn": {
+                                                    "type": "integer"
+                                                },
+                                                "fail": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "checks": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "status": {
+                                                        "type": "string"
+                                                    },
+                                                    "weight": {
+                                                        "type": "integer"
+                                                    },
+                                                    "message": {
+                                                        "type": "string"
+                                                    },
+                                                    "current": {
+                                                        "type": "string"
+                                                    },
+                                                    "fix": {}
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "topFixes": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "severity": {
+                                                        "type": "string"
+                                                    },
+                                                    "fix": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "url": "https://citable.run/",
+                                    "finalUrl": "https://citable.run/",
+                                    "fetchedAt": "2026-08-24T20:43:12.086Z",
+                                    "http": {
+                                        "status": 200,
+                                        "redirects": 0,
+                                        "contentType": "text/html; charset=UTF-8",
+                                        "responseMs": 2011,
+                                        "bytes": 68900,
+                                        "truncated": false,
+                                        "https": true
+                                    },
+                                    "page": {
+                                        "title": {
+                                            "text": "Citable \u2014 SEO and AI-visibility checks for agents",
+                                            "length": 49
+                                        },
+                                        "metaDescription": {
+                                            "text": "Pay-per-call SEO and AI-visibility data for AI agents. \u2026",
+                                            "length": 178
+                                        },
+                                        "canonical": "https://citable.run/",
+                                        "lang": "en",
+                                        "headings": {
+                                            "counts": {},
+                                            "h1": [
+                                                "SEO and AI-visibility checks for agents."
+                                            ]
+                                        },
+                                        "wordCount": 1279,
+                                        "links": {
+                                            "total": 8,
+                                            "internal": 5,
+                                            "external": 3,
+                                            "nofollow": 0
+                                        },
+                                        "images": {
+                                            "total": 0,
+                                            "missingAlt": 0,
+                                            "emptyAlt": 0
+                                        },
+                                        "structuredData": {
+                                            "count": 1,
+                                            "invalid": 0,
+                                            "types": [
+                                                "FAQPage"
+                                            ]
+                                        }
+                                    },
+                                    "aiAccess": {
+                                        "robotsTxt": "missing",
+                                        "llmsTxt": false,
+                                        "bots": {
+                                            "gptbot": "allowed",
+                                            "claudebot": "allowed",
+                                            "perplexitybot": "allowed",
+                                            "google-extended": "allowed",
+                                            "ccbot": "allowed"
+                                        }
+                                    },
+                                    "answerability": {
+                                        "questionHeadings": 0,
+                                        "hasDate": false,
+                                        "hasAuthor": false
+                                    },
+                                    "score": 92,
+                                    "summary": {
+                                        "pass": 15,
+                                        "warn": 5,
+                                        "fail": 0
+                                    },
+                                    "checks": [
+                                        {
+                                            "id": "http-status",
+                                            "status": "pass",
+                                            "weight": 8,
+                                            "message": "Returns 200 OK",
+                                            "current": "200",
+                                            "fix": null
+                                        }
+                                    ],
+                                    "topFixes": [
+                                        {
+                                            "id": "meta-description",
+                                            "severity": "warn",
+                                            "fix": "Rewrite the meta description to 70\u2013160 characters"
+                                        }
+                                    ],
+                                    "price": "$0.01",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -551,7 +1482,94 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prompt": {
+                                            "type": "string"
+                                        },
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "mentioned": {
+                                            "type": "boolean"
+                                        },
+                                        "engines": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "engine": {
+                                                        "type": "string"
+                                                    },
+                                                    "ok": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "mentioned": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "position": {},
+                                                    "cited": {
+                                                        "type": "array",
+                                                        "items": {}
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "summary": {
+                                            "type": "object",
+                                            "properties": {
+                                                "engines_run": {
+                                                    "type": "integer"
+                                                },
+                                                "engines_ok": {
+                                                    "type": "integer"
+                                                },
+                                                "engines_citing": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "note": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "prompt": "best pay-per-call seo api",
+                                    "domain": "citable.run",
+                                    "mentioned": false,
+                                    "engines": [
+                                        {
+                                            "engine": "perplexity",
+                                            "ok": true,
+                                            "mentioned": false,
+                                            "position": null,
+                                            "cited": [
+                                                {}
+                                            ]
+                                        }
+                                    ],
+                                    "summary": {
+                                        "engines_run": 4,
+                                        "engines_ok": 4,
+                                        "engines_citing": 0
+                                    },
+                                    "note": "One run per engine; answers vary between runs. Citations come from each engine's official API, which can differ from its web UI.",
+                                    "price": "$0.20",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -614,7 +1632,109 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "pages": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "page": {
+                                                        "type": "string"
+                                                    },
+                                                    "mentions": {
+                                                        "type": "integer"
+                                                    },
+                                                    "aiSearchVolume": {
+                                                        "type": "integer"
+                                                    },
+                                                    "engines": {
+                                                        "type": "array",
+                                                        "items": {}
+                                                    },
+                                                    "languages": {
+                                                        "type": "array",
+                                                        "items": {}
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "totalCitedPages": {
+                                            "type": "integer"
+                                        },
+                                        "domainTotals": {
+                                            "type": "object",
+                                            "properties": {
+                                                "mentions": {
+                                                    "type": "integer"
+                                                },
+                                                "aiSearchVolume": {
+                                                    "type": "integer"
+                                                },
+                                                "engines": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "languages": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "domain": "example.com",
+                                    "pages": [
+                                        {
+                                            "page": "https://example.com/docs/getting-started",
+                                            "mentions": 412,
+                                            "aiSearchVolume": 38900,
+                                            "engines": [
+                                                {}
+                                            ],
+                                            "languages": [
+                                                {}
+                                            ]
+                                        }
+                                    ],
+                                    "totalCitedPages": 128,
+                                    "domainTotals": {
+                                        "mentions": 1930,
+                                        "aiSearchVolume": 141200,
+                                        "engines": [
+                                            "\u2026"
+                                        ],
+                                        "languages": [
+                                            "\u2026"
+                                        ]
+                                    },
+                                    "source": "dataforseo_llm_mentions",
+                                    "price": "$0.22",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -686,7 +1806,118 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "prompts": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "question": {
+                                                        "type": "string"
+                                                    },
+                                                    "answer": {
+                                                        "type": "string"
+                                                    },
+                                                    "platform": {
+                                                        "type": "string"
+                                                    },
+                                                    "aiSearchVolume": {
+                                                        "type": "integer"
+                                                    },
+                                                    "citedUrl": {
+                                                        "type": "string"
+                                                    },
+                                                    "citedRank": {
+                                                        "type": "integer"
+                                                    },
+                                                    "firstSeen": {
+                                                        "type": "string"
+                                                    },
+                                                    "lastSeen": {
+                                                        "type": "string"
+                                                    },
+                                                    "webSearchBased": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "observations": {
+                                                        "type": "integer"
+                                                    },
+                                                    "brandEntities": {
+                                                        "type": "array"
+                                                    },
+                                                    "fanOutQueries": {
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "totalPrompts": {
+                                            "type": "integer"
+                                        },
+                                        "coverage": {
+                                            "type": "object",
+                                            "properties": {
+                                                "platforms": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "note": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "domain": "profound.com",
+                                    "prompts": [
+                                        {
+                                            "question": "profound",
+                                            "answer": "**Profound** is an adjective that means very great, deep, or intense \u2026",
+                                            "platform": "google",
+                                            "aiSearchVolume": 1300,
+                                            "citedUrl": "https://www.profound.com/",
+                                            "citedRank": 5,
+                                            "firstSeen": "2025-11-28 23:57:09 +00:00",
+                                            "lastSeen": "2026-08-17 19:15:17 +00:00",
+                                            "webSearchBased": true,
+                                            "observations": 4,
+                                            "brandEntities": [],
+                                            "fanOutQueries": []
+                                        }
+                                    ],
+                                    "totalPrompts": 7,
+                                    "coverage": {
+                                        "platforms": [
+                                            "chat_gpt"
+                                        ],
+                                        "note": "ChatGPT rows are United States / English only; brandEntities and fanOutQueries are ChatGPT-only fields"
+                                    },
+                                    "source": "dataforseo_llm_mentions",
+                                    "price": "$0.25",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -767,7 +1998,110 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "months": {
+                                            "type": "array",
+                                            "items": {}
+                                        },
+                                        "summary": {
+                                            "type": "object",
+                                            "properties": {
+                                                "totalMentions": {
+                                                    "type": "integer"
+                                                },
+                                                "firstMonth": {
+                                                    "type": "string"
+                                                },
+                                                "lastMonth": {
+                                                    "type": "string"
+                                                },
+                                                "latestMentions": {
+                                                    "type": "integer"
+                                                },
+                                                "previousMentions": {
+                                                    "type": "integer"
+                                                },
+                                                "change": {
+                                                    "type": "integer"
+                                                },
+                                                "changePct": {
+                                                    "type": "integer"
+                                                },
+                                                "direction": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "coverage": {
+                                            "type": "object",
+                                            "properties": {
+                                                "platforms": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "indexStart": {
+                                                    "type": "string"
+                                                },
+                                                "note": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "domain": "profound.com",
+                                    "months": [
+                                        {
+                                            "month": "2025-08",
+                                            "mentions": 1,
+                                            "aiSearchVolume": 10,
+                                            "mentionsChange": null,
+                                            "mentionsChangePct": null
+                                        }
+                                    ],
+                                    "summary": {
+                                        "totalMentions": 22,
+                                        "firstMonth": "2025-08",
+                                        "lastMonth": "2026-08",
+                                        "latestMentions": 3,
+                                        "previousMentions": 2,
+                                        "change": 1,
+                                        "changePct": 50,
+                                        "direction": "up"
+                                    },
+                                    "coverage": {
+                                        "platforms": [
+                                            "chat_gpt"
+                                        ],
+                                        "indexStart": "2025-08-01",
+                                        "note": "Monthly buckets from an aggregated AI-answer index; ChatGPT rows are United States / English only"
+                                    },
+                                    "source": "dataforseo_llm_mentions",
+                                    "price": "$0.18",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -830,7 +2164,125 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "domains": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "leader": {
+                                            "type": "string"
+                                        },
+                                        "totals": {
+                                            "type": "object",
+                                            "properties": {
+                                                "mentions": {
+                                                    "type": "integer"
+                                                },
+                                                "aiSearchVolume": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "domain": {
+                                                        "type": "string"
+                                                    },
+                                                    "rank": {
+                                                        "type": "integer"
+                                                    },
+                                                    "mentions": {
+                                                        "type": "integer"
+                                                    },
+                                                    "aiSearchVolume": {
+                                                        "type": "integer"
+                                                    },
+                                                    "sharePct": {
+                                                        "type": "integer"
+                                                    },
+                                                    "engines": {
+                                                        "type": "array",
+                                                        "items": {}
+                                                    },
+                                                    "languages": {
+                                                        "type": "array",
+                                                        "items": {}
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "coverage": {
+                                            "type": "object",
+                                            "properties": {
+                                                "platforms": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "note": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "domains": [
+                                        "semrush.com"
+                                    ],
+                                    "leader": "semrush.com",
+                                    "totals": {
+                                        "mentions": 86629,
+                                        "aiSearchVolume": 92800939
+                                    },
+                                    "results": [
+                                        {
+                                            "domain": "semrush.com",
+                                            "rank": 1,
+                                            "mentions": 71069,
+                                            "aiSearchVolume": 80461811,
+                                            "sharePct": 82,
+                                            "engines": [
+                                                {}
+                                            ],
+                                            "languages": [
+                                                {}
+                                            ]
+                                        }
+                                    ],
+                                    "coverage": {
+                                        "platforms": [
+                                            "chat_gpt"
+                                        ],
+                                        "note": "sharePct is each domain's share of the compared set, not of the whole index; ChatGPT rows are United States / English only"
+                                    },
+                                    "source": "dataforseo_llm_mentions",
+                                    "price": "$0.18",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -902,7 +2354,164 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "prompt": {
+                                            "type": "string"
+                                        },
+                                        "onpage": {
+                                            "type": "object",
+                                            "properties": {
+                                                "url": {
+                                                    "type": "string"
+                                                },
+                                                "score": {
+                                                    "type": "integer"
+                                                },
+                                                "summary": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "pass": {
+                                                            "type": "integer"
+                                                        },
+                                                        "warn": {
+                                                            "type": "integer"
+                                                        },
+                                                        "fail": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "checks": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "topFixes": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "visibility": {
+                                            "type": "object",
+                                            "properties": {
+                                                "mentioned": {
+                                                    "type": "boolean"
+                                                },
+                                                "engines": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "summary": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "engines_run": {
+                                                            "type": "integer"
+                                                        },
+                                                        "engines_ok": {
+                                                            "type": "integer"
+                                                        },
+                                                        "engines_citing": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "topCitedPages": {
+                                            "type": "object",
+                                            "properties": {
+                                                "pages": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "totalCitedPages": {
+                                                    "type": "integer"
+                                                },
+                                                "domainTotals": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "mentions": {
+                                                            "type": "integer"
+                                                        },
+                                                        "aiSearchVolume": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "domain": "citable.run",
+                                    "prompt": "best pay-per-call seo api",
+                                    "onpage": {
+                                        "url": "https://citable.run/",
+                                        "score": 92,
+                                        "summary": {
+                                            "pass": 15,
+                                            "warn": 5,
+                                            "fail": 0
+                                        },
+                                        "checks": [
+                                            "\u2026"
+                                        ],
+                                        "topFixes": [
+                                            "\u2026"
+                                        ]
+                                    },
+                                    "visibility": {
+                                        "mentioned": false,
+                                        "engines": [
+                                            "\u2026"
+                                        ],
+                                        "summary": {
+                                            "engines_run": 4,
+                                            "engines_ok": 4,
+                                            "engines_citing": 0
+                                        }
+                                    },
+                                    "topCitedPages": {
+                                        "pages": [
+                                            "\u2026"
+                                        ],
+                                        "totalCitedPages": 0,
+                                        "domainTotals": {
+                                            "mentions": 0,
+                                            "aiSearchVolume": 0
+                                        }
+                                    },
+                                    "price": "$0.30",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -974,7 +2583,88 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "country": {
+                                            "type": "string"
+                                        },
+                                        "lang": {
+                                            "type": "string"
+                                        },
+                                        "organic": {
+                                            "type": "object",
+                                            "properties": {
+                                                "keywords": {
+                                                    "type": "integer"
+                                                },
+                                                "top3": {
+                                                    "type": "integer"
+                                                },
+                                                "top10": {
+                                                    "type": "integer"
+                                                },
+                                                "top100": {
+                                                    "type": "integer"
+                                                },
+                                                "estTraffic": {
+                                                    "type": "integer"
+                                                },
+                                                "estTrafficValue": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "paid": {
+                                            "type": "object",
+                                            "properties": {
+                                                "keywords": {
+                                                    "type": "integer"
+                                                },
+                                                "estTraffic": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "domain": "ahrefs.com",
+                                    "country": "us",
+                                    "lang": "en",
+                                    "organic": {
+                                        "keywords": 120400,
+                                        "top3": 8100,
+                                        "top10": 24800,
+                                        "top100": 120400,
+                                        "estTraffic": 1310000,
+                                        "estTrafficValue": 2280000
+                                    },
+                                    "paid": {
+                                        "keywords": 25,
+                                        "estTraffic": 1400
+                                    },
+                                    "source": "dataforseo_labs",
+                                    "price": "$0.03",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -1055,7 +2745,89 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "country": {
+                                            "type": "string"
+                                        },
+                                        "lang": {
+                                            "type": "string"
+                                        },
+                                        "keywords": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "keyword": {
+                                                        "type": "string"
+                                                    },
+                                                    "volume": {
+                                                        "type": "integer"
+                                                    },
+                                                    "cpc": {
+                                                        "type": "number"
+                                                    },
+                                                    "position": {
+                                                        "type": "integer"
+                                                    },
+                                                    "url": {
+                                                        "type": "string"
+                                                    },
+                                                    "previousPosition": {
+                                                        "type": "integer"
+                                                    },
+                                                    "change": {
+                                                        "type": "integer"
+                                                    },
+                                                    "status": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "totalKeywords": {
+                                            "type": "integer"
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "domain": "ahrefs.com",
+                                    "country": "us",
+                                    "lang": "en",
+                                    "keywords": [
+                                        {
+                                            "keyword": "backlink checker",
+                                            "volume": 74000,
+                                            "cpc": 6.2,
+                                            "position": 1,
+                                            "url": "https://ahrefs.com/backlink-checker",
+                                            "previousPosition": 1,
+                                            "change": 0,
+                                            "status": "same"
+                                        }
+                                    ],
+                                    "totalKeywords": 120400,
+                                    "source": "dataforseo_labs",
+                                    "price": "$0.04",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -1136,7 +2908,145 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "country": {
+                                            "type": "string"
+                                        },
+                                        "lang": {
+                                            "type": "string"
+                                        },
+                                        "months": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "month": {
+                                                        "type": "string"
+                                                    },
+                                                    "organic": {
+                                                        "type": "object"
+                                                    },
+                                                    "paid": {
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "trend": {
+                                            "type": "object",
+                                            "properties": {
+                                                "keywords": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "first": {
+                                                            "type": "integer"
+                                                        },
+                                                        "last": {
+                                                            "type": "integer"
+                                                        },
+                                                        "delta": {
+                                                            "type": "integer"
+                                                        },
+                                                        "deltaPct": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "top10": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "first": {
+                                                            "type": "integer"
+                                                        },
+                                                        "last": {
+                                                            "type": "integer"
+                                                        },
+                                                        "delta": {
+                                                            "type": "integer"
+                                                        },
+                                                        "deltaPct": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                },
+                                                "estTraffic": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "first": {
+                                                            "type": "integer"
+                                                        },
+                                                        "last": {
+                                                            "type": "integer"
+                                                        },
+                                                        "delta": {
+                                                            "type": "integer"
+                                                        },
+                                                        "deltaPct": {
+                                                            "type": "number"
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "domain": "ahrefs.com",
+                                    "country": "us",
+                                    "lang": "en",
+                                    "months": [
+                                        {
+                                            "month": "2026-06",
+                                            "organic": {},
+                                            "paid": {}
+                                        }
+                                    ],
+                                    "trend": {
+                                        "keywords": {
+                                            "first": 118200,
+                                            "last": 120400,
+                                            "delta": 2200,
+                                            "deltaPct": 1.9
+                                        },
+                                        "top10": {
+                                            "first": 24100,
+                                            "last": 24800,
+                                            "delta": 700,
+                                            "deltaPct": 2.9
+                                        },
+                                        "estTraffic": {
+                                            "first": 1270000,
+                                            "last": 1310000,
+                                            "delta": 40000,
+                                            "deltaPct": 3.1
+                                        }
+                                    },
+                                    "source": "dataforseo_labs",
+                                    "price": "$0.03",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -1217,7 +3127,91 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "keyword": {
+                                            "type": "string"
+                                        },
+                                        "gl": {
+                                            "type": "string"
+                                        },
+                                        "hl": {
+                                            "type": "string"
+                                        },
+                                        "results": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "position": {
+                                                        "type": "integer"
+                                                    },
+                                                    "domain": {
+                                                        "type": "string"
+                                                    },
+                                                    "url": {
+                                                        "type": "string"
+                                                    },
+                                                    "title": {
+                                                        "type": "string"
+                                                    },
+                                                    "snippet": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "peopleAlsoAsk": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "relatedSearches": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "keyword": "seo api",
+                                    "gl": "us",
+                                    "hl": "en",
+                                    "results": [
+                                        {
+                                            "position": 1,
+                                            "domain": "dataforseo.com",
+                                            "url": "https://dataforseo.com/",
+                                            "title": "DataForSEO: Powerful API Stack For Data-Driven SEO Tools",
+                                            "snippet": "Discover DataForSEO APIs \u2026"
+                                        }
+                                    ],
+                                    "peopleAlsoAsk": [
+                                        "What is an SEO API?"
+                                    ],
+                                    "relatedSearches": [
+                                        "seo api free"
+                                    ],
+                                    "source": "serper",
+                                    "price": "$0.008",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {
@@ -1280,7 +3274,97 @@
                     "200": {
                         "description": "The check result as JSON.",
                         "content": {
-                            "application/json": {}
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "domain": {
+                                            "type": "string"
+                                        },
+                                        "summary": {
+                                            "type": "object",
+                                            "properties": {
+                                                "backlinks": {
+                                                    "type": "integer"
+                                                },
+                                                "referringDomains": {
+                                                    "type": "integer"
+                                                },
+                                                "referringMainDomains": {
+                                                    "type": "integer"
+                                                },
+                                                "domainRank": {
+                                                    "type": "integer"
+                                                },
+                                                "brokenBacklinks": {
+                                                    "type": "integer"
+                                                },
+                                                "nofollow": {
+                                                    "type": "integer"
+                                                },
+                                                "firstSeen": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        },
+                                        "referringDomains": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "domain": {
+                                                        "type": "string"
+                                                    },
+                                                    "backlinks": {
+                                                        "type": "integer"
+                                                    },
+                                                    "rank": {
+                                                        "type": "integer"
+                                                    },
+                                                    "firstSeen": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "additionalProperties": true
+                                            }
+                                        },
+                                        "source": {
+                                            "type": "string"
+                                        },
+                                        "price": {
+                                            "type": "string"
+                                        },
+                                        "cluster": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                },
+                                "example": {
+                                    "domain": "example.com",
+                                    "summary": {
+                                        "backlinks": 1930,
+                                        "referringDomains": 128,
+                                        "referringMainDomains": 120,
+                                        "domainRank": 312,
+                                        "brokenBacklinks": 4,
+                                        "nofollow": 22,
+                                        "firstSeen": "2023-01-05"
+                                    },
+                                    "referringDomains": [
+                                        {
+                                            "domain": "news.io",
+                                            "backlinks": 240,
+                                            "rank": 410,
+                                            "firstSeen": "2024-02-02"
+                                        }
+                                    ],
+                                    "source": "dataforseo_backlinks",
+                                    "price": "$0.10",
+                                    "cluster": "mainnet"
+                                }
+                            }
                         }
                     },
                     "400": {


### PR DESCRIPTION
Adds `providers/citable/seo` — SEO and AI-visibility data on 17 paid GET routes, settled in USDC on Solana mainnet via x402 v2 (`exact` scheme, PayAI facilitator).

```
pay catalog check providers/citable/seo/PAY.md
PAY.md check successful
17 endpoints tested across 1 provider
17/17 gates compatible with Solana
```

The OpenAPI spec is committed next to PAY.md (pretty-printed) and copied verbatim from the live https://citable.run/openapi.json.

Two things the validator improved on our side, both now deployed to production:

- Operation summaries used to read `Backlinks — $0.10`. Since that line becomes the reason shown on a payment prompt, they are now verb-first ASCII sentences within 24-63 chars — `Look up a domain's backlinks and referring domains` — with a test holding the contract.
- Every paid operation carries `x-payment-info` (price mode, currency, and the x402 network/asset/payTo), and `info.x-guidance` explains the pay-and-retry flow in one paragraph.

Every route answers 402 with no parameters, so probes reach the challenge without guessing arguments; each challenge also carries a Bazaar discovery extension with the route's query parameters and a sample response. No account or API key exists — the wallet is the identity — and any 4xx/5xx cancels the payment instead of settling it, so a failed call is never charged.

Also indexed on x402scan with all 17 resources verified: https://www.x402scan.com/server/2c5be88d-dc11-4463-afad-5c415c302d6f