### PR TITLE
fix(modelstudio): add qwen 3.8 variants

### DIFF
--- a/providers/solana-foundation/alibaba/modelstudio/openapi.json
+++ b/providers/solana-foundation/alibaba/modelstudio/openapi.json
@@ -373,6 +373,114 @@
           "variants": [
             {
               "param": "model",
+              "value": "qwen3.8-max",
+              "description": "Qwen 3.8 Max, including dated aliases.",
+              "dimensions": [
+                {
+                  "direction": "input",
+                  "unit": "tokens",
+                  "scale": 1000000,
+                  "tiers": [
+                    {
+                      "price_usd": 1.999
+                    }
+                  ]
+                },
+                {
+                  "direction": "output",
+                  "unit": "tokens",
+                  "scale": 1000000,
+                  "tiers": [
+                    {
+                      "price_usd": 5.996
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "param": "model",
+              "value": "qwen3.8-flash",
+              "description": "Qwen 3.8 Flash, including dated aliases.",
+              "dimensions": [
+                {
+                  "direction": "input",
+                  "unit": "tokens",
+                  "scale": 1000000,
+                  "tiers": [
+                    {
+                      "price_usd": 0.146
+                    }
+                  ]
+                },
+                {
+                  "direction": "output",
+                  "unit": "tokens",
+                  "scale": 1000000,
+                  "tiers": [
+                    {
+                      "price_usd": 0.457
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "param": "model",
+              "value": "qwen3.8-2.4t-a95b",
+              "description": "Qwen 3.8 2.4T A95B, including dated aliases.",
+              "dimensions": [
+                {
+                  "direction": "input",
+                  "unit": "tokens",
+                  "scale": 1000000,
+                  "tiers": [
+                    {
+                      "price_usd": 1.999
+                    }
+                  ]
+                },
+                {
+                  "direction": "output",
+                  "unit": "tokens",
+                  "scale": 1000000,
+                  "tiers": [
+                    {
+                      "price_usd": 5.996
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "param": "model",
+              "value": "qwen3.8-27b",
+              "description": "Qwen 3.8 27B, including dated aliases.",
+              "dimensions": [
+                {
+                  "direction": "input",
+                  "unit": "tokens",
+                  "scale": 1000000,
+                  "tiers": [
+                    {
+                      "price_usd": 0.487
+                    }
+                  ]
+                },
+                {
+                  "direction": "output",
+                  "unit": "tokens",
+                  "scale": 1000000,
+                  "tiers": [
+                    {
+                      "price_usd": 2.917
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "param": "model",
               "value": "qwen3.7-max",
               "description": "Qwen 3.7 Max, including dated aliases.",
               "dimensions": [


### PR DESCRIPTION
## Summary
- add Qwen 3.8 Max, Flash, 2.4T A95B, and 27B to the Model Studio catalog
- publish the deployed input and output token prices for picker filtering and metering

## Test Plan
- `pay catalog check providers/solana-foundation/alibaba/modelstudio/PAY.md --no-probe`
- `jq empty providers/solana-foundation/alibaba/modelstudio/openapi.json`