### PR TITLE
docs: fix README openapi example to use committed path, not url

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ use_case: "Use for ..."                    # 32–255 chars, helps LLMs route
 category: compute                          # see categories list below
 service_url: https://x402.quicknode.com    # production HTTPS URL, no IPs
 openapi:
-  url: https://x402.quicknode.com/openapi.json
-  # OR (for co-located specs):
-  # path: openapi.json
+  path: openapi.json                       # commit the spec next to PAY.md
 ---
 
 Free-form prose. Explain what the API offers, when an agent should reach


### PR DESCRIPTION
## What

The primary README provider example uses `openapi: { url: ... }`:

```yaml
openapi:
  url: https://x402.quicknode.com/openapi.json
  # OR (for co-located specs):
  # path: openapi.json
```

But `CONTRIBUTING.md` states in three separate places that this form is **rejected**:
- line 41 — *"Pointing at a remote URL with `openapi: { url: ... }` is no longer accepted"*
- line 131 — *"`openapi.url` is rejected by CI"*
- line 298 (checklist) — *"committed as a sidecar … not referenced by URL"*

And every current provider in the repo already uses `path:` or inline `content:` — none uses `url:`. So a contributor following the most prominent example produces a submission CI rejects on the first round-trip.

## Change

Make the committed-sidecar form the example, matching the documented and enforced policy:

```yaml
openapi:
  path: openapi.json                       # commit the spec next to PAY.md
```

Docs-only, one file. Found during an external review of the registry; the companion catalog/spec note is #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)